### PR TITLE
MINDEXER-89: Use a more uncommon port for Jetty in the DefaultIndexUpdaterEmbeddingIT to avoid "Address already in use"

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -193,7 +193,6 @@ under the License.
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
                 <indexerJar>${project.build.directory}/${project.artifactId}-${project.version}-cli.jar</indexerJar>
-                <index-server>${index-server}</index-server>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterEmbeddingIT.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterEmbeddingIT.java
@@ -21,6 +21,7 @@ package org.apache.maven.index.updater;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,18 +59,11 @@ public class DefaultIndexUpdaterEmbeddingIT
     public void setUp()
         throws Exception
     {
-        // FIXME: Try to detect the port from the system environment.
-        int port = -1;
-        String portStr = System.getProperty( "index-server" );
-        if ( portStr != null )
+        int port;
+        try ( final ServerSocket ss = new ServerSocket( 0 ) )
         {
-            port = Integer.parseInt( portStr );
-        }
-
-        if ( port < 1024 )
-        {
-            System.out.println( "Using default port: 8080" );
-            port = 8080;
+            ss.setReuseAddress( true );
+            port = ss.getLocalPort();
         }
 
         baseUrl = "http://127.0.0.1:" + port + "/";


### PR DESCRIPTION
Applied fix suggested by Tamas.
