### PR TITLE
Add minimal information to a newly created artifact info (using the IndexUtils method), linking it to the context it belongs to.

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
@@ -122,6 +122,10 @@ public class IndexUtils
 
         ArtifactInfo artifactInfo = new ArtifactInfo();
 
+        // Add minimal information to the artifact info linking it to the context it belongs to.
+        artifactInfo.setRepository(context.getRepositoryId());
+        artifactInfo.setContext(context.getId());
+
         for ( IndexCreator ic : context.getIndexCreators() )
         {
             res |= ic.updateArtifactInfo( doc, artifactInfo );


### PR DESCRIPTION
While trying to write an IndexCreator, I`ve discovered that the ArtifactInfo instance that I received in the IndexCreator.updateDocument method was improperly constructed.

Digging further, I discovered that the updateDocument method is called by IndexUtils.updateDocument that, in turn, constructs its ArtifactInfo instance by calling IndexUtils.constructArtifactInfo(doc, context).

It turns out that the IndexUtils.constructArtifactInfo method uses the no-arguments constructor for creating an ArtifactInfo instance and relies on the IndexCreators to populate it. However, **it does not set the repositoryId or contextId fields on this new instance**, leaving it in an inconsistent state (with values for the artifact, but without the ability to properly identify the artifact, i.e. where it comes from).

The simple solution is to add this information right after the no-argument constructor call and before the indexCreators, so that, in their run, the index creators also become aware of the source of the artifactInfo that they are augmenting.

As a bonus, looking at the call Hierarchy of the ArtifactInfo.setRepository method it seems that there are about 4 places where this is done by hand as a result of the bad behavior of IndexUtils.constructArtifactInfo, so making this change might also remove a bit of duplicate code.