### PR TITLE
resolve performance loss due to lucene 4.8.1 - upgrade to lucene 553 and additional fixes

### DIFF
--- a/indexer-cli/src/main/java/org/apache/maven/index/cli/NexusIndexerCli.java
+++ b/indexer-cli/src/main/java/org/apache/maven/index/cli/NexusIndexerCli.java
@@ -418,7 +418,7 @@ public class NexusIndexerCli
         final List<IndexCreator> indexers = getIndexers( cli, plexus );
 
         try (BufferedInputStream is = new BufferedInputStream( new FileInputStream( indexArchive ) ); //
-             FSDirectory directory = FSDirectory.open( outputFolder ))
+             FSDirectory directory = FSDirectory.open( outputFolder.toPath() ))
         {
             DefaultIndexUpdater.unpackIndexData( is, directory, (IndexingContext) Proxy.newProxyInstance(
                 getClass().getClassLoader(), new Class[] { IndexingContext.class }, new PartialImplementation()

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIteratorResultSet.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIteratorResultSet.java
@@ -368,7 +368,6 @@ public class DefaultIteratorResultSet
         
         Analyzer analyzer = context.getAnalyzer();
         TokenStream baseTokenStream = analyzer.tokenStream( field.getKey(), new StringReader( text ) );
-        baseTokenStream.reset();
         
         CachingTokenFilter tokenStream = new CachingTokenFilter(baseTokenStream);
 
@@ -388,9 +387,6 @@ public class DefaultIteratorResultSet
         }
 
         List<String> bestFragments = getBestFragments( hr.getQuery(), formatter, tokenStream, text, 3 );
-        
-        tokenStream.end();
-        tokenStream.close();
         
         return bestFragments;
     }

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultNexusIndexer.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultNexusIndexer.java
@@ -279,7 +279,7 @@ public class DefaultNexusIndexer
         IndexingContext tmpContext = null;
         try
         {
-            final FSDirectory directory = FSDirectory.open( tmpDir );
+            final FSDirectory directory = FSDirectory.open( tmpDir.toPath() );
             if ( update )
             {
                 IndexUtils.copyDirectory( context.getIndexDirectory(), directory );

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultQueryCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultQueryCreator.java
@@ -141,7 +141,7 @@ public class DefaultQueryCreator
         }
         else
         {
-            QueryParser qp = new QueryParser( Version.LUCENE_46, field, new NexusAnalyzer() );
+            QueryParser qp = new QueryParser( field, new NexusAnalyzer() );
 
             // small cheap trick
             // if a query is not "expert" (does not contain field:val kind of expression)
@@ -273,7 +273,7 @@ public class DefaultQueryCreator
             {
                 String qpQuery = query.toLowerCase().replaceAll( "\\.", " " ).replaceAll( "/", " " );
                 // tokenization should happen against the field!
-                QueryParser qp = new QueryParser( Version.LUCENE_46, indexerField.getKey(), new NexusAnalyzer() );
+                QueryParser qp = new QueryParser( indexerField.getKey(), new NexusAnalyzer() );
                 qp.setDefaultOperator( Operator.AND );
                 return qp.parse( qpQuery );
             }
@@ -306,7 +306,7 @@ public class DefaultQueryCreator
                 String qpQuery = query;
 
                 // tokenization should happen against the field!
-                QueryParser qp = new QueryParser( Version.LUCENE_46, indexerField.getKey(), new NexusAnalyzer() );
+                QueryParser qp = new QueryParser( indexerField.getKey(), new NexusAnalyzer() );
                 qp.setDefaultOperator( Operator.AND );
 
                 // small cheap trick

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
@@ -261,7 +261,7 @@ public class DefaultScannerListener
         {
             for ( String uinfo : uinfos )
             {
-                TopScoreDocCollector collector = TopScoreDocCollector.create( 1, false );
+                TopScoreDocCollector collector = TopScoreDocCollector.create( 1 );
 
                 indexSearcher.search( new TermQuery( new Term( ArtifactInfo.UINFO, uinfo ) ), collector );
 

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
@@ -330,7 +330,7 @@ public class DefaultSearchEngine
         if ( AbstractSearchRequest.UNDEFINED != topHitCount )
         {
             // count is set, simply just execute it as-is
-            final TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount, true );
+            final TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount );
 
             indexSearcher.search( query, hits );
 
@@ -342,7 +342,7 @@ public class DefaultSearchEngine
             topHitCount = 1000;
 
             // perform search
-            TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount, true );
+            TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount );
             indexSearcher.search( query, hits );
 
             // check total hits against, does it fit?
@@ -361,7 +361,7 @@ public class DefaultSearchEngine
                 }
 
                 // redo all, but this time with correct numbers
-                hits = TopScoreDocCollector.create( topHitCount, true );
+                hits = TopScoreDocCollector.create( topHitCount );
                 indexSearcher.search( query, hits );
             }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/context/AbstractIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/AbstractIndexingContext.java
@@ -28,7 +28,8 @@ public abstract class AbstractIndexingContext
     {
         try
         {
-            return getIndexDirectory().fileExists( INDEX_UPDATER_PROPERTIES_FILE );
+            getIndexDirectory().fileLength(INDEX_UPDATER_PROPERTIES_FILE);
+            return true;
         }
         catch ( IOException e )
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -21,6 +21,11 @@ package org.apache.maven.index.context;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -45,6 +50,9 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.FSLockFactory;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.artifact.GavCalculator;
@@ -76,6 +84,8 @@ public class DefaultIndexingContext
     private static final Term DESCRIPTOR_TERM = new Term( FLD_DESCRIPTOR, FLD_DESCRIPTOR_CONTENTS );
 
     private Directory indexDirectory;
+
+    private TrackingLockFactory lockFactory;
 
     private File indexDirectoryFile;
 
@@ -111,6 +121,7 @@ public class DefaultIndexingContext
                                     File repository, //
                                     String repositoryUrl, String indexUpdateUrl,
                                     List<? extends IndexCreator> indexCreators, Directory indexDirectory,
+                                    TrackingLockFactory lockFactory,
                                     boolean reclaimIndex )
         throws ExistingLuceneIndexMismatchException, IOException
     {
@@ -134,6 +145,8 @@ public class DefaultIndexingContext
 
         this.indexDirectory = indexDirectory;
 
+        this.lockFactory = lockFactory;
+
         // eh?
         // Guice does NOT initialize these, and we have to do manually?
         // While in Plexus, all is well, but when in guice-shim,
@@ -150,15 +163,24 @@ public class DefaultIndexingContext
         setIndexDirectoryFile( null );
     }
 
+    private DefaultIndexingContext( String id, String repositoryId, File repository, File indexDirectoryFile,
+                                   TrackingLockFactory lockFactory, String repositoryUrl, String indexUpdateUrl,
+                                   List<? extends IndexCreator> indexCreators, boolean reclaimIndex )
+        throws IOException, ExistingLuceneIndexMismatchException
+    {
+        this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators,
+            FSDirectory.open( indexDirectoryFile.toPath(), lockFactory ), lockFactory, reclaimIndex );
+
+        setIndexDirectoryFile( indexDirectoryFile );
+    }
+    
     public DefaultIndexingContext( String id, String repositoryId, File repository, File indexDirectoryFile,
                                    String repositoryUrl, String indexUpdateUrl,
                                    List<? extends IndexCreator> indexCreators, boolean reclaimIndex )
         throws IOException, ExistingLuceneIndexMismatchException
     {
-        this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators,
-            FSDirectory.open( indexDirectoryFile ), reclaimIndex );
-
-        setIndexDirectoryFile( indexDirectoryFile );
+                this( id, repositoryId, repository, indexDirectoryFile, new TrackingLockFactory(FSLockFactory.getDefault()),
+                        repositoryUrl, indexUpdateUrl, indexCreators, reclaimIndex);
     }
 
     @Deprecated
@@ -167,11 +189,11 @@ public class DefaultIndexingContext
                                    List<? extends IndexCreator> indexCreators, boolean reclaimIndex )
         throws IOException, ExistingLuceneIndexMismatchException
     {
-        this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators, indexDirectory, reclaimIndex );
+        this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators, indexDirectory, null, reclaimIndex ); //Lock factory already installed - pass null
 
         if ( indexDirectory instanceof FSDirectory )
         {
-            setIndexDirectoryFile(( (FSDirectory) indexDirectory ).getDirectory() );
+            setIndexDirectoryFile(( (FSDirectory) indexDirectory ).getDirectory().toFile() );
         }
     }
 
@@ -215,7 +237,7 @@ public class DefaultIndexingContext
                 // unlock the dir forcibly
                 if ( IndexWriter.isLocked( indexDirectory ) )
                 {
-                    IndexWriter.unlock( indexDirectory );
+                    unlockForciebly( lockFactory, indexDirectory );
                 }
 
                 openAndWarmup();
@@ -252,7 +274,7 @@ public class DefaultIndexingContext
             // unlock the dir forcibly
             if ( IndexWriter.isLocked( indexDirectory ) )
             {
-                IndexWriter.unlock( indexDirectory );
+                unlockForciebly( lockFactory, indexDirectory );
             }
 
             deleteIndexFiles( true );
@@ -281,7 +303,7 @@ public class DefaultIndexingContext
         // check for descriptor if this is not a "virgin" index
         if ( getSize() > 0 )
         {
-            final TopScoreDocCollector collector = TopScoreDocCollector.create( 1, false );
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 1 );
             final IndexSearcher indexSearcher = acquireIndexSearcher();
             try
             {
@@ -369,14 +391,17 @@ public class DefaultIndexingContext
 
             if ( full )
             {
-                if ( indexDirectory.fileExists( INDEX_PACKER_PROPERTIES_FILE ) )
-                {
+                
+                try {
                     indexDirectory.deleteFile( INDEX_PACKER_PROPERTIES_FILE );
+                } catch (IOException ioe) {
+                    //Does not exist
                 }
 
-                if ( indexDirectory.fileExists( INDEX_UPDATER_PROPERTIES_FILE ) )
-                {
+                try {
                     indexDirectory.deleteFile( INDEX_UPDATER_PROPERTIES_FILE );
+                } catch (IOException ioe) {
+                    //Does not exist
                 }
             }
 
@@ -612,7 +637,7 @@ public class DefaultIndexingContext
         try
         {
             final IndexWriter w = getIndexWriter();
-            final IndexReader directoryReader = IndexReader.open( directory);
+            final IndexReader directoryReader = DirectoryReader.open( directory);
             TopScoreDocCollector collector = null;
             try
             {
@@ -635,7 +660,7 @@ public class DefaultIndexingContext
                     String uinfo = d.get( ArtifactInfo.UINFO );
                     if ( uinfo != null )
                     {
-                        collector = TopScoreDocCollector.create( 1, false );
+                        collector = TopScoreDocCollector.create( 1 );
                         s.search( new TermQuery( new Term( ArtifactInfo.UINFO, uinfo ) ), collector );
                         if ( collector.getTotalHits() == 0 )
                         {
@@ -706,7 +731,7 @@ public class DefaultIndexingContext
 
     public List<IndexCreator> getIndexCreators()
     {
-        return Collections.unmodifiableList( indexCreators );
+        return Collections.<IndexCreator>unmodifiableList( indexCreators );
     }
 
     // groups
@@ -784,7 +809,7 @@ public class DefaultIndexingContext
     protected Set<String> getGroups( String field, String filedValue, String listField )
         throws IOException, CorruptIndexException
     {
-        final TopScoreDocCollector collector = TopScoreDocCollector.create( 1, false );
+        final TopScoreDocCollector collector = TopScoreDocCollector.create( 1);
         final IndexSearcher indexSearcher = acquireIndexSearcher();
         try
         {
@@ -832,5 +857,44 @@ public class DefaultIndexingContext
     public String toString()
     {
         return id + " : " + timestamp;
+    }
+
+    private static void unlockForciebly(final TrackingLockFactory lockFactory, final Directory dir) throws IOException
+    {
+        //Warning: Not doable in lucene >= 5.3 consider to remove it as IndexWriter.unlock
+        //was always strongly non recommended by Lucene.
+        //For now try to do the best to simulate the IndexWriter.unlock at least on FSDirectory
+        //using FSLockFactory, the RAMDirectory uses SingleInstanceLockFactory.
+        //custom lock factory?
+        if (lockFactory != null) {
+            final Set<? extends Lock> emittedLocks = lockFactory.getEmittedLocks(IndexWriter.WRITE_LOCK_NAME);
+            for (Lock emittedLock : emittedLocks) {
+                emittedLock.close();
+            }
+        }
+        if (dir instanceof FSDirectory) {
+            final FSDirectory fsdir = (FSDirectory) dir;
+            final Path dirPath = fsdir.getDirectory();
+            if (Files.isDirectory(dirPath)) {
+                Path lockPath = dirPath.resolve(IndexWriter.WRITE_LOCK_NAME);
+                try {
+                    lockPath = lockPath.toRealPath();
+                } catch (IOException ioe) {
+                    //Not locked
+                    return;
+                }
+                try (final FileChannel fc = FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+                    final FileLock lck = fc.tryLock();
+                    if (lck == null) {
+                        //Still active
+                        throw new LockObtainFailedException("Lock held by another process: " + lockPath);
+                    } else {
+                        //Not held fine to release
+                        lck.close();
+                    }
+                }
+                Files.delete(lockPath);
+            }
+        }
     }
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -125,6 +125,7 @@ public class DefaultIndexingContext
                                     boolean reclaimIndex )
         throws ExistingLuceneIndexMismatchException, IOException
     {
+
         this.id = id;
 
         this.searchable = true;
@@ -612,6 +613,12 @@ public class DefaultIndexingContext
     public synchronized void replace( Directory directory )
         throws IOException
     {
+        replace(directory, null, null);
+    }
+
+    public synchronized void replace( Directory directory, Set<String> allGroups, Set<String> rootGroups)
+        throws IOException
+    {
         final Date ts = IndexUtils.getTimestamp( directory );
         closeReaders();
         deleteIndexFiles( false );
@@ -619,7 +626,16 @@ public class DefaultIndexingContext
         openAndWarmup();
         // reclaim the index as mine
         storeDescriptor();
+        if(allGroups == null && rootGroups == null) {
         rebuildGroups();
+        } else {
+            if(allGroups != null) {
+                setAllGroups(allGroups);
+            }
+            if(rootGroups != null) {
+                setRootGroups(rootGroups);
+            }
+        }
         updateTimestamp( true, ts );
         optimize();
     }

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -572,7 +572,6 @@ public class DefaultIndexingContext
     public synchronized void optimize()
         throws CorruptIndexException, IOException
     {
-        getIndexWriter().forceMerge(1);
         commit();
     }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
@@ -129,12 +129,18 @@ public class IndexUtils
 
     public static Document updateDocument( Document doc, IndexingContext context, boolean updateLastModified )
     {
-        ArtifactInfo ai = constructArtifactInfo( doc, context );
-        if ( ai == null )
-        {
-            return doc;
-        }
+         return updateDocument(doc, context, updateLastModified, null);
+    }
 
+    public static Document updateDocument( Document doc, IndexingContext context, boolean updateLastModified, ArtifactInfo ai )
+    {
+        if( ai == null ) {
+            ai = constructArtifactInfo( doc, context );
+            if ( ai == null )
+            {
+                return doc;
+            }
+        }
         Document document = new Document();
 
         // unique key

--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexingContext.java
@@ -268,6 +268,9 @@ public interface IndexingContext
     void replace( Directory directory )
         throws IOException;
 
+    void replace( Directory directory, Set<String> allGroups, Set<String> rootGroups )
+        throws IOException;
+
     Directory getIndexDirectory();
 
     File getIndexDirectoryFile();

--- a/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
@@ -282,6 +282,12 @@ public class MergedIndexingContext
         // noop
     }
 
+    public void replace( Directory directory, Set<String> allGroups, Set<String> rootGroups )
+        throws IOException
+    {
+        // noop
+    }
+
     public Directory getIndexDirectory()
     {
         return directory;

--- a/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
@@ -79,7 +79,7 @@ public class MergedIndexingContext
                                   boolean searchable, ContextMemberProvider membersProvider )
         throws IOException
     {
-        this( membersProvider, id, repositoryId, repository, FSDirectory.open( indexDirectoryFile ), searchable );
+        this( membersProvider, id, repositoryId, repository, FSDirectory.open( indexDirectoryFile.toPath() ), searchable );
 
         setIndexDirectoryFile( indexDirectoryFile );
     }
@@ -93,7 +93,7 @@ public class MergedIndexingContext
 
         if ( indexDirectory instanceof FSDirectory )
         {
-            setIndexDirectoryFile( ( (FSDirectory) indexDirectory ).getDirectory() );
+            setIndexDirectoryFile( ( (FSDirectory) indexDirectory ).getDirectory().toFile() );
         }
     }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
@@ -28,7 +28,6 @@ import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.SerialMergeScheduler;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.LockObtainFailedException;
-import org.apache.lucene.util.Version;
 
 /**
  * An extension of <a
@@ -43,7 +42,7 @@ public class NexusIndexWriter
         throws CorruptIndexException, LockObtainFailedException, IOException
     {
         //super( directory, analyzer, create, MaxFieldLength.LIMITED );
-        this(directory, new IndexWriterConfig(Version.LUCENE_46, analyzer));
+        this(directory, new IndexWriterConfig(analyzer));
 
         // setSimilarity( new NexusSimilarity() );
     }
@@ -58,7 +57,7 @@ public class NexusIndexWriter
 
     public static IndexWriterConfig defaultConfig()
     {
-        final IndexWriterConfig config = new IndexWriterConfig( Version.LUCENE_46, new NexusAnalyzer() );
+        final IndexWriterConfig config = new IndexWriterConfig( new NexusAnalyzer() );
         // default open mode is CreateOrAppend which suits us
         config.setRAMBufferSizeMB( 2.0 ); // old default
         config.setMergeScheduler( new SerialMergeScheduler() ); // merging serially

--- a/indexer-core/src/main/java/org/apache/maven/index/context/TrackingLockFactory.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/TrackingLockFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0    
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.index.context;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockFactory;
+import static com.google.common.base.Preconditions.checkNotNull;
+import java.util.HashSet;
+
+/**
+ *
+ * @author Tomas Zezula
+ */
+final class TrackingLockFactory extends LockFactory {
+
+    private final LockFactory delegate;
+    private final Set<TrackingLock> emittedLocks;
+
+    TrackingLockFactory(final LockFactory delegate) {
+        this.delegate = checkNotNull(delegate);
+        this.emittedLocks = Collections.newSetFromMap(new ConcurrentHashMap<TrackingLock,Boolean>());
+    }
+
+    Set<? extends Lock> getEmittedLocks(String name) {
+        final Set<Lock> result = new HashSet<>();
+        for (TrackingLock lock : emittedLocks) {
+            if (name == null || name.equals(lock.getName())) {
+                result.add(lock);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Lock obtainLock(Directory dir, String lockName) throws IOException {
+        final TrackingLock lck = new TrackingLock(
+                delegate.obtainLock(dir, lockName),
+                lockName);
+        emittedLocks.add(lck);
+        return lck;
+    }
+
+
+    private final class TrackingLock extends Lock {
+        private final Lock delegate;
+        private final String name;
+
+        TrackingLock(
+                final Lock delegate,
+                final String name) {
+            this.delegate = checkNotNull(delegate);
+            this.name = checkNotNull(name);
+        }
+
+        String getName() {
+            return name;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                delegate.close();
+            } finally {
+                emittedLocks.remove(this);
+            }
+        }
+
+        @Override
+        public void ensureValid() throws IOException {
+            delegate.ensureValid();
+        }
+    }
+}

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -289,7 +289,6 @@ public class DefaultIndexUpdater
             // analyzer is unimportant, since we are not adding/searching to/on index, only reading/deleting
             w = new NexusIndexWriter( directory, new NexusAnalyzer(), false );
 
-            w.forceMerge(4);
             w.commit();
         }
         finally

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -49,6 +49,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexableField;
@@ -260,7 +261,7 @@ public class DefaultIndexUpdater
         IndexWriter w = null;
         try
         {
-            r = IndexReader.open( directory );
+            r = DirectoryReader.open( directory );
             w = new NexusIndexWriter( directory, new NexusAnalyzer(), false );
             
             Bits liveDocs = MultiFields.getLiveDocs(r);

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/FSDirectoryFactory.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/FSDirectoryFactory.java
@@ -40,7 +40,7 @@ public interface FSDirectoryFactory
         public FSDirectory open( File indexDir )
             throws IOException
         {
-            return FSDirectory.open( indexDir );
+            return FSDirectory.open( indexDir.toPath() );
         }
     };
 

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -109,9 +109,6 @@ public class IndexDataReader
         }
 
         w.commit();
-        
-        w.forceMerge(1);
-        w.commit();
 
         IndexDataReadResult result = new IndexDataReadResult();
         result.setDocumentCount( n );

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -30,6 +30,8 @@ import java.util.Date;
 import java.util.zip.GZIPInputStream;
 
 import com.google.common.base.Strings;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Index;
@@ -89,10 +91,21 @@ public class IndexDataReader
         int n = 0;
 
         Document doc;
+        Set<String> rootGroups = new LinkedHashSet<>();
+        Set<String> allGroups = new LinkedHashSet<>();
+        
         while ( ( doc = readDocument() ) != null )
         {
-            w.addDocument( IndexUtils.updateDocument( doc, context, false ) );
+            ArtifactInfo ai = IndexUtils.constructArtifactInfo( doc, context );
+            if(ai != null) {
+                w.addDocument( IndexUtils.updateDocument( doc, context, false, ai ) );
 
+                rootGroups.add( ai.getRootGroup() );
+                allGroups.add( ai.getGroupId() );
+
+            } else {
+                w.addDocument( doc );
+            }
             n++;
         }
 
@@ -104,6 +117,9 @@ public class IndexDataReader
         IndexDataReadResult result = new IndexDataReadResult();
         result.setDocumentCount( n );
         result.setTimestamp( date );
+        result.setRootGroups( rootGroups );
+        result.setAllGroups( allGroups );
+        
         return result;
     }
 
@@ -292,6 +308,10 @@ public class IndexDataReader
 
         private int documentCount;
 
+        private Set<String> rootGroups;
+
+        private Set<String> allGroups;
+        
         public void setDocumentCount( int documentCount )
         {
             this.documentCount = documentCount;
@@ -310,6 +330,26 @@ public class IndexDataReader
         public Date getTimestamp()
         {
             return timestamp;
+        }
+
+        public void setRootGroups(Set<String> rootGroups)
+        {
+            this.rootGroups = rootGroups;
+        }
+
+        public Set<String> getRootGroups()
+        {
+            return rootGroups;
+        }
+
+        public void setAllGroups(Set<String> allGroups)
+        {
+            this.allGroups = allGroups;
+        }
+
+        public Set<String> getAllGroups()
+        {
+            return allGroups;
         }
 
     }

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -53,27 +53,26 @@ public class IndexDataReader
     public IndexDataReader( InputStream is )
         throws IOException
     {
-        BufferedInputStream bis = new BufferedInputStream( is, 1024 * 8 );
-
         // MINDEXER-13
         // LightweightHttpWagon may have performed automatic decompression
         // Handle it transparently
-        bis.mark( 2 );
+        is.mark( 2 );
         InputStream data;
-        if ( bis.read() == 0x1f && bis.read() == 0x8b ) // GZIPInputStream.GZIP_MAGIC
+        if ( is.read() == 0x1f && is.read() == 0x8b ) // GZIPInputStream.GZIP_MAGIC
         {
-            bis.reset();
-            data = new GZIPInputStream( bis, 2 * 1024 );
+            is.reset();
+            data = new BufferedInputStream(new GZIPInputStream( is, 1024 * 8 ), 1024 * 8 );
         }
         else
         {
+            BufferedInputStream bis = new BufferedInputStream( is, 1024 * 8 );
             bis.reset();
             data = bis;
         }
 
         this.dis = new DataInputStream( data );
     }
-
+    
     public IndexDataReadResult readIndex( IndexWriter w, IndexingContext context )
         throws IOException
     {

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
@@ -34,6 +34,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiFields;
@@ -242,7 +243,7 @@ public class IndexDataWriter
     public void writeField( IndexableField field )
         throws IOException
     {
-        int flags = ( field.fieldType().indexed() ? F_INDEXED : 0 ) //
+        int flags = ( field.fieldType().indexOptions() != IndexOptions.NONE  ? F_INDEXED : 0 ) //
             + ( field.fieldType().tokenized() ? F_TOKENIZED : 0 ) //
             + ( field.fieldType().stored() ? F_STORED : 0 ); //
         // + ( false ? F_COMPRESSED : 0 ); // Compressed not supported anymore

--- a/indexer-core/src/test/java/org/apache/maven/index/DefaultIndexNexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/DefaultIndexNexusIndexerTest.java
@@ -181,7 +181,7 @@ public class DefaultIndexNexusIndexerTest
 
         File newIndex = new File( getBasedir(), "target/test-new" );
 
-        Directory newIndexDir = FSDirectory.open( newIndex );
+        Directory newIndexDir = FSDirectory.open( newIndex.toPath() );
 
         IndexingContext newContext =
             nexusIndexer.addIndexingContext( "test-new", "test", null, newIndexDir, null, null, DEFAULT_CREATORS );
@@ -223,7 +223,7 @@ public class DefaultIndexNexusIndexerTest
 
         newContext.close( false );
 
-        newIndexDir = FSDirectory.open( newIndex );
+        newIndexDir = FSDirectory.open( newIndex.toPath());
 
         newContext =
             nexusIndexer.addIndexingContext( "test-new", "test", null, newIndexDir, null, null, DEFAULT_CREATORS );

--- a/indexer-core/src/test/java/org/apache/maven/index/FSDirectoryDeleteTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/FSDirectoryDeleteTest.java
@@ -53,13 +53,13 @@ public class FSDirectoryDeleteTest
 
         nexusIndexer = lookup( NexusIndexer.class );
 
-        indexDir = FSDirectory.open( indexDirFile );
+        indexDir = FSDirectory.open( indexDirFile.toPath() );
 
         context = nexusIndexer.addIndexingContext( "one", "nexus-13", repo, indexDir, null, null, DEFAULT_CREATORS );
 
         nexusIndexer.scan( context );
 
-        otherIndexDir = FSDirectory.open( otherIndexDirFile );
+        otherIndexDir = FSDirectory.open( otherIndexDirFile.toPath() );
 
         otherContext =
             nexusIndexer.addIndexingContext( "other", "nexus-13", repo, otherIndexDir, null, null, DEFAULT_CREATORS );

--- a/indexer-core/src/test/java/org/apache/maven/index/FullIndexNexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/FullIndexNexusIndexerTest.java
@@ -356,7 +356,7 @@ public class FullIndexNexusIndexerTest
 
         File newIndex = new File( getBasedir(), "target/test-new" );
 
-        Directory newIndexDir = FSDirectory.open( newIndex );
+        Directory newIndexDir = FSDirectory.open( newIndex.toPath() );
 
         IndexingContext newContext =
             nexusIndexer.addIndexingContext( "test-new", "test", null, newIndexDir, null, null, DEFAULT_CREATORS );
@@ -397,7 +397,7 @@ public class FullIndexNexusIndexerTest
 
         newContext.close( false );
 
-        newIndexDir = FSDirectory.open( newIndex );
+        newIndexDir = FSDirectory.open( newIndex.toPath() );
 
         newContext =
             nexusIndexer.addIndexingContext( "test-new", "test", null, newIndexDir, null, null, DEFAULT_CREATORS );

--- a/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
@@ -118,13 +118,13 @@ public class NexusIndexerTest
         // scored search against field having untokenized indexerField only
         q = indexer.constructQuery( MAVEN.PACKAGING, "maven-archetype", SearchType.SCORED );
 
-        assertEquals( "p:maven-archetype p:maven-archetype*^0.8", q.toString() );
+        assertEquals( "p:maven-archetype p:maven-archetype*", q.toString() );
 
         // scored search against field having untokenized indexerField only
         q = indexer.constructQuery( MAVEN.ARTIFACT_ID, "commons-logging", SearchType.SCORED );
 
         assertEquals(
-            "(a:commons-logging a:commons-logging*^0.8) ((+artifactId:commons +artifactId:logging*) artifactId:\"commons logging\")",
+            "(a:commons-logging a:commons-logging*) ((+artifactId:commons +artifactId:logging*) artifactId:\"commons logging\")",
             q.toString() );
 
         // scored search against field having tokenized IndexerField only (should be impossible).

--- a/indexer-core/src/test/java/org/apache/maven/index/archetype/NexusArchetypeDataSourceTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/archetype/NexusArchetypeDataSourceTest.java
@@ -70,7 +70,7 @@ public class NexusArchetypeDataSourceTest
 
             super.deleteDirectory( indexDirFile );
 
-            indexDir = FSDirectory.open( indexDirFile );
+            indexDir = FSDirectory.open( indexDirFile.toPath() );
         }
 
         File repo = new File( getBasedir(), "src/test/repo" );

--- a/indexer-core/src/test/java/org/apache/maven/index/context/NexusAnalyzerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/context/NexusAnalyzerTest.java
@@ -55,7 +55,7 @@ public class NexusAnalyzerTest
     protected void runAndCompare( IndexerField indexerField, String text, String[] expected )
         throws IOException
     {
-        Tokenizer ts = (Tokenizer) nexusAnalyzer.createComponents(indexerField.getKey(), new StringReader( text ) ).getTokenizer();
+        Tokenizer ts = (Tokenizer) nexusAnalyzer.tokenStream(indexerField.getKey(), new StringReader( text ) );
         ts.reset();
 
         ArrayList<String> tokenList = new ArrayList<String>();

--- a/indexer-core/src/test/java/org/apache/maven/index/context/TrackingLockFactoryTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/context/TrackingLockFactoryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0    
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.index.context;
+
+import java.io.IOException;
+import java.util.Set;
+import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.LockObtainFailedException;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.SingleInstanceLockFactory;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author Tomas Zezula
+ */
+public class TrackingLockFactoryTest {
+
+    public TrackingLockFactoryTest() {
+    }
+
+    @Test
+    public void testLockUnlock() throws IOException {
+        final TrackingLockFactory lf = new TrackingLockFactory(new SingleInstanceLockFactory());
+        final RAMDirectory ram = new RAMDirectory(lf);
+        final Lock foo = ram.obtainLock("foo");
+        final Lock bar = ram.obtainLock("bar");
+        bar.close();
+        foo.close();
+        ram.close();
+    }
+
+    @Test
+    public void testLockLocked() throws IOException {
+        final TrackingLockFactory lf = new TrackingLockFactory(new SingleInstanceLockFactory());
+        final RAMDirectory ram = new RAMDirectory(lf);
+        final Lock foo = ram.obtainLock("foo");
+        boolean thrownLOFE = false;
+        try {
+            ram.obtainLock("foo");
+        } catch (LockObtainFailedException e) {
+            thrownLOFE = true;
+        }
+        assertTrue(thrownLOFE);
+        foo.close();
+        final Lock foo2 = ram.obtainLock("foo");
+        foo2.close();
+        ram.close();
+    }
+
+    @Test
+    public void testEmmittedLocks() throws IOException {
+        final TrackingLockFactory lf = new TrackingLockFactory(new SingleInstanceLockFactory());
+        final RAMDirectory ram = new RAMDirectory(lf);
+        final Lock l1 = ram.obtainLock("l1");
+        final Lock l2 = ram.obtainLock("l2");
+        final Lock l3 = ram.obtainLock("l3");
+        l2.close();
+        Set<? extends Lock> emittedLocks = lf.getEmittedLocks(null);
+        assertEquals(2, emittedLocks.size());
+        assertTrue(emittedLocks.contains(l1));
+        assertTrue(emittedLocks.contains(l3));
+        emittedLocks = lf.getEmittedLocks("l3");
+        assertEquals(1, emittedLocks.size());
+        assertTrue(emittedLocks.contains(l3));
+    }
+}

--- a/indexer-core/src/test/java/org/apache/maven/index/packer/NEXUS4149TransferFormatTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/packer/NEXUS4149TransferFormatTest.java
@@ -19,9 +19,11 @@ package org.apache.maven.index.packer;
  * under the License.
  */
 
+import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
@@ -140,7 +142,7 @@ public class NEXUS4149TransferFormatTest
         }
 
         // read it up and verify, but stay "low level", directly consume the GZ file and count
-        FileInputStream fis = new FileInputStream( new File( packTargetDir, "nexus-maven-repository-index.gz" ) );
+        InputStream fis = new BufferedInputStream( new FileInputStream( new File( packTargetDir, "nexus-maven-repository-index.gz" ) ) );
         IndexDataReader reader = new IndexDataReader( fis );
         try
         {

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
@@ -420,7 +420,7 @@ public class DefaultIndexUpdaterTest
                     with( IndexingContext.INDEX_FILE_PREFIX + ".gz" ) );
                 will( returnValue( newInputStream( "/index-updater/server-root/nexus-maven-repository-index.gz" ) ) );
 
-                oneOf( tempContext ).replace( with( any( Directory.class ) ) );
+                oneOf( tempContext ).replace( with( any( Directory.class ) ), with( any( Set.class ) ), with( any( Set.class ) ) );
 
                 oneOf( mockFetcher ).disconnect();
             }
@@ -578,7 +578,7 @@ public class DefaultIndexUpdaterTest
                 will( returnValue( newInputStream( "/index-updater/server-root/nexus-maven-repository-index.gz" ) ) );
                 // could create index archive there and verify that it is merged correctly
 
-                oneOf( tempContext ).replace( with( any( Directory.class ) ) );
+                oneOf( tempContext ).replace( with( any( Directory.class ) ), with( any( Set.class ) ), with( any( Set.class ) ) );
 
                 never( mockFetcher ).retrieve( //
                     with( IndexingContext.INDEX_FILE_PREFIX + ".2.gz" ) );
@@ -822,7 +822,7 @@ public class DefaultIndexUpdaterTest
 
                 never( tempContext ).merge( with( any( Directory.class ) ) );
 
-                oneOf( tempContext ).replace( with( any( Directory.class ) ) );
+                oneOf( tempContext ).replace( with( any( Directory.class ) ), with( any( Set.class ) ), with( any( Set.class ) ) );
 
                 oneOf( mockFetcher ).disconnect();
             }

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
@@ -150,7 +150,11 @@ public class DefaultIndexUpdaterTest
             Collection<ArtifactInfo> tempContent = tempResponse.getResults();
             assertEquals( tempContent.toString(), 3, tempContent.size() );
 
-            RAMDirectory tempDir2 = new RAMDirectory( tempContext.getIndexDirectory(), IOContext.DEFAULT );
+            RAMDirectory tempDir2 = new RAMDirectory();
+            for (String file : tempContext.getIndexDirectory().listAll())
+            {
+                tempDir2.copyFrom(tempContext.getIndexDirectory(), file, file, IOContext.DEFAULT);
+            }
 
             indexer.removeIndexingContext( tempContext, false );
 
@@ -193,7 +197,11 @@ public class DefaultIndexUpdaterTest
             indexer.deleteArtifactFromIndex(
                 createArtifactContext( repositoryId, "commons-lang", "commons-lang", "2.4", null ), tempContext );
 
-            RAMDirectory tempDir2 = new RAMDirectory( tempContext.getIndexDirectory(), IOContext.DEFAULT );
+            RAMDirectory tempDir2 = new RAMDirectory();
+            for (String file : tempContext.getIndexDirectory().listAll())
+            {
+                tempDir2.copyFrom(tempContext.getIndexDirectory(), file, file, IOContext.DEFAULT);
+            }
 
             indexer.removeIndexingContext( tempContext, false );
 
@@ -267,7 +275,11 @@ public class DefaultIndexUpdaterTest
             indexer.addArtifactToIndex(
                 createArtifactContext( repositoryId, "org.slf4j.foo", "jcl104-over-slf4j", "1.4.2", null ), context );
 
-            RAMDirectory tempDir2 = new RAMDirectory( tempContext.getIndexDirectory(), IOContext.DEFAULT );
+            RAMDirectory tempDir2 = new RAMDirectory();
+            for (String file : tempContext.getIndexDirectory().listAll())
+            {
+                tempDir2.copyFrom(tempContext.getIndexDirectory(), file, file, IOContext.DEFAULT);
+            }
 
             indexer.removeIndexingContext( tempContext, false );
 

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
@@ -84,7 +84,7 @@ public class IndexDataTest
 
         newDir = new RAMDirectory();
 
-        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context );
+        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context ).getTimestamp();
 
         assertEquals( timestamp, newTimestamp );
 
@@ -121,7 +121,7 @@ public class IndexDataTest
 
         newDir = new RAMDirectory();
 
-        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context );
+        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context ).getTimestamp();
 
         assertEquals( null, newTimestamp );
 

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.CorruptIndexException;
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
@@ -134,7 +135,7 @@ public class IndexDataTest
 
         Map<String, ArtifactInfo> r1map = readIndex( r1 );
 
-        IndexReader r2 = IndexReader.open( newDir );
+        IndexReader r2 = DirectoryReader.open( newDir );
 
         Map<String, ArtifactInfo> r2map = readIndex( r2 );
 

--- a/indexer-core/src/test/resources/testQueryCreatorNGSearch/case01.txt
+++ b/indexer-core/src/test/resources/testQueryCreatorNGSearch/case01.txt
@@ -1,4 +1,4 @@
-### Searched for field urn:maven#groupId (with 2 registered index fields) using query "commons-logg" (QC create LQL "(g:commons-logg g:commons-logg*^0.8) ((+groupId:commons +groupId:logg*) groupId:"commons logg")")
+### Searched for field urn:maven#groupId (with 2 registered index fields) using query "commons-logg" (QC create LQL "(g:commons-logg g:commons-logg*) ((+groupId:commons +groupId:logg*) groupId:"commons logg")")
 test :: commons-logging:commons-logging:1.1:null:jar
 test :: commons-logging:commons-logging:1.1:sources:jar
 test :: commons-logging:commons-logging:1.0.4:null:jar

--- a/indexer-core/src/test/resources/testQueryCreatorNGSearch/case05.txt
+++ b/indexer-core/src/test/resources/testQueryCreatorNGSearch/case05.txt
@@ -1,4 +1,4 @@
-### Searched for field urn:maven#version (with 2 registered index fields) using query "1.0" (QC create LQL "(v:1.0 v:1.0*^0.8) ((+version:1 +version:0*) version:"1 0")")
+### Searched for field urn:maven#version (with 2 registered index fields) using query "1.0" (QC create LQL "(v:1.0 v:1.0*) ((+version:1 +version:0*) version:"1 0")")
 test :: proptest:proptest-archetype:1.0:null:maven-archetype
 test :: org.apache.maven.plugins:maven-core-it-plugin:1.0:null:maven-plugin
 test :: org.apache.maven.plugins:maven-core-it-plugin:1.0:sources:jar

--- a/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
+++ b/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
@@ -61,11 +61,11 @@ public class RepositoryIndexer
 
     private static final Logger LOGGER = LoggerFactory.getLogger( RepositoryIndexer.class );
 
-    private static final Version luceneVersion = Version.LUCENE_48;
+    private static final Version luceneVersion = Version.LUCENE_4_8;
 
     private static final String[] luceneFields = new String[]{ "g", "a", "v", "p", "c" };
 
-    private static final WhitespaceAnalyzer luceneAnalyzer = new WhitespaceAnalyzer( luceneVersion );
+    private static final WhitespaceAnalyzer luceneAnalyzer = new WhitespaceAnalyzer( );
 
     private Indexer indexer;
 
@@ -176,7 +176,7 @@ public class RepositoryIndexer
     public Set<ArtifactInfo> search( final String queryText )
         throws ParseException, IOException
     {
-        final Query query = new MultiFieldQueryParser( luceneVersion, luceneFields, luceneAnalyzer ).parse( queryText );
+        final Query query = new MultiFieldQueryParser( luceneFields, luceneAnalyzer ).parse( queryText );
 
         LOGGER.debug( "Executing search query: {}; ctx id: {}; idx dir: {}",
                       new String[]{ query.toString(), indexingContext.getId(),

--- a/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
+++ b/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
@@ -61,8 +61,6 @@ public class RepositoryIndexer
 
     private static final Logger LOGGER = LoggerFactory.getLogger( RepositoryIndexer.class );
 
-    private static final Version luceneVersion = Version.LUCENE_4_8;
-
     private static final String[] luceneFields = new String[]{ "g", "a", "v", "p", "c" };
 
     private static final WhitespaceAnalyzer luceneAnalyzer = new WhitespaceAnalyzer( );

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@ under the License.
     <eclipse-sisu.version>0.2.1</eclipse-sisu.version>
     <sisu-guice.version>3.2.2</sisu-guice.version>
 
-    <lucene.version>4.8.1</lucene.version>
+    <lucene.version>5.5.3</lucene.version>
     <maven.version>3.0.5</maven.version>
     <aether.version>1.0.0.v20140518</aether.version>
 


### PR DESCRIPTION
since lucene was upgraded to 4.8.1 the indexer takes 2.5x longer than with lucene 3.6. This seems be a cumulative effect of partial reductions in performance introduced in particular lucene releases after 3.6 - see also https://issues.apache.org/jira/browse/MINDEXER-99

see the particular commits in this request. Each addresses a suggestion for a specific improvement. When all applied, the resulting performance is comparable with the performance before the above mentioned upgrade.
# 0bb9484 - upgrading lucene from 4.8.1 to 5.5.3

performance was improved in lucene 5.x.
with 5.5.3 the indexer works significantly faster than with 4.8.1
# 3cfa430 - avoid rebuilding groups after reading index

after generating the index it has to be re-read one more time to extract a distinct list of allGroups and rootGroups, even though that info was already available, but thrown away.
# 8b98a49 - improve reading from zip file
#4062146 - do not unnecessarily force merge on index writer

merge is very expensive - lets trust lucene to merge when it seems fit. 
the final index size without force merges was 910mb compared to 900mb with fm.
the time improvement is aprox 30%
