### PR TITLE
Migrate to Lucene 7

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
@@ -29,8 +29,6 @@ import java.util.List;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
 import org.apache.maven.index.artifact.Gav;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexingContext;
@@ -167,10 +165,10 @@ public class ArtifactContext
         Document doc = new Document();
 
         // unique key
-        doc.add( new Field( ArtifactInfo.UINFO, getArtifactInfo().getUinfo(), Store.YES, Index.NOT_ANALYZED ) );
+        doc.add( new Field( ArtifactInfo.UINFO, getArtifactInfo().getUinfo(),FieldTypeFactory.getStoredNotAnalyzedFieldType()) );
 
         doc.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-            Long.toString( System.currentTimeMillis() ), Store.YES, Index.NO ) );
+            Long.toString( System.currentTimeMillis() ), FieldTypeFactory.getStoredNotIndexedFieldType()) );
 
         for ( IndexCreator indexCreator : context.getIndexCreators() )
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfoRecord.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfoRecord.java
@@ -22,9 +22,6 @@ package org.apache.maven.index;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
-
 /**
  * Pulling out ArtifactInfo, clearing up. TBD. This gonna be extensible "map-like" class with fields.
  * 
@@ -53,14 +50,13 @@ public class ArtifactInfoRecord
      * Unique groupId, artifactId, version, classifier, extension (or packaging). Stored, indexed untokenized
      */
     public static final IndexerField FLD_UINFO = new IndexerField( NEXUS.UINFO, IndexerFieldVersion.V1, "u",
-        "Artifact UINFO (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "Artifact UINFO (as keyword, stored)", FieldTypeFactory.getStoredNotAnalyzedFieldType());
 
     /**
      * Del: contains UINFO to mark record as deleted (needed for incremental updates!). The original document IS
      * removed, but this marker stays on index to note that fact.
      */
     public static final IndexerField FLD_DELETED = new IndexerField( NEXUS.DELETED, IndexerFieldVersion.V1, "del",
-        "Deleted field, will contain UINFO if document is deleted from index (not indexed, stored)", Store.YES,
-        Index.NO );
+        "Deleted field, will contain UINFO if document is deleted from index (not indexed, stored)", FieldTypeFactory.getStoredNotIndexedFieldType());
 
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
@@ -100,9 +100,9 @@ public class DefaultIndexerEngine
             // add artifact deletion marker
             final Document doc = new Document();
 
-            doc.add( new Field( ArtifactInfo.DELETED, uinfo, Field.Store.YES, Field.Index.NO ) );
+            doc.add( new Field( ArtifactInfo.DELETED, uinfo, FieldTypeFactory.getStoredNotIndexedFieldType()) );
             doc.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-                Long.toString( System.currentTimeMillis() ), Field.Store.YES, Field.Index.NO ) );
+                Long.toString( System.currentTimeMillis() ),FieldTypeFactory.getStoredNotIndexedFieldType()));
 
             IndexWriter w = context.getIndexWriter();
             w.addDocument( doc );

--- a/indexer-core/src/main/java/org/apache/maven/index/FieldTypeFactory.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/FieldTypeFactory.java
@@ -1,0 +1,38 @@
+package org.apache.maven.index;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0    
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.lucene.document.FieldType;
+
+public class FieldTypeFactory {
+	
+	private static StoredNotAnalyzedFieldType snaft = new StoredNotAnalyzedFieldType();
+	private static StoredNotIndexedFieldType snift = new StoredNotIndexedFieldType();
+	
+	
+	public static FieldType getStoredNotAnalyzedFieldType() {
+		return snaft;
+	}
+	
+	public static FieldType getStoredNotIndexedFieldType() {
+		return snift;
+	}
+
+}

--- a/indexer-core/src/main/java/org/apache/maven/index/IndexerField.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/IndexerField.java
@@ -20,9 +20,8 @@ package org.apache.maven.index;
  */
 
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.Field.TermVector;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
 
 /**
  * Holds basic information about Indexer field, how it is stored. To keep this centralized, and not spread across code.
@@ -38,34 +37,20 @@ public class IndexerField
 
     private final String key;
 
-    private final Store storeMethod;
-
-    private final Index indexMethod;
-
-    private final TermVector termVector;
+	private final FieldType fieldType;
 
     public IndexerField( final org.apache.maven.index.Field ontology, final IndexerFieldVersion version,
-                         final String key, final String description, final Store storeMethod, final Index indexMethod )
+                         final String key, final String description, FieldType fieldType)
     {
-        this( ontology, version, key, description, storeMethod, indexMethod, null );
-    }
 
-    public IndexerField( final org.apache.maven.index.Field ontology, final IndexerFieldVersion version,
-                         final String key, final String description, final Store storeMethod, final Index indexMethod,
-                         final TermVector termVector )
-    {
-        this.ontology = ontology;
+    	this.ontology = ontology;
 
         this.version = version;
 
         this.key = key;
 
-        this.storeMethod = storeMethod;
-
-        this.indexMethod = indexMethod;
-
-        this.termVector = termVector;
-
+        this.fieldType = fieldType;
+        
         ontology.addIndexerField( this );
     }
 
@@ -84,55 +69,23 @@ public class IndexerField
         return key;
     }
 
-    public Field.Store getStoreMethod()
-    {
-        return storeMethod;
-    }
-
-    public Field.Index getIndexMethod()
-    {
-        return indexMethod;
-    }
-
-    public Field.TermVector getTermVector()
-    {
-        return termVector;
-    }
-
     public boolean isIndexed()
     {
-        return !Index.NO.equals( indexMethod );
+        return fieldType.indexOptions().equals(IndexOptions.NONE);
     }
 
     public boolean isKeyword()
     {
-        return isIndexed() && !Index.ANALYZED.equals( indexMethod );
+        return isIndexed() && !fieldType.omitNorms();
     }
 
     public boolean isStored()
     {
-        return !( Store.NO.equals( storeMethod ) );
+        return fieldType.stored();
     }
 
     public Field toField( String value )
     {
-        Field result;
-
-        if ( getTermVector() != null )
-        {
-            result = new Field( getKey(), value, getStoreMethod(), getIndexMethod(), getTermVector() );
-        }
-        else
-        {
-            result = new Field( getKey(), value, getStoreMethod(), getIndexMethod() );
-        }
-
-        // if ( isKeyword() )
-        // {
-        // result.setOmitNorms( true );
-        // result.setOmitTf( true );
-        // }
-
-        return result;
+        return new Field( getKey(), value, fieldType);
     }
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/OneLineFragmenter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/OneLineFragmenter.java
@@ -19,8 +19,8 @@ package org.apache.maven.index;
  * under the License.
  */
 
-import org.apache.lucene.analysis.Token;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
 import org.apache.lucene.search.highlight.Fragmenter;
 
 public class OneLineFragmenter
@@ -33,7 +33,7 @@ public class OneLineFragmenter
         setText( originalText );
     }
 
-    public boolean isNewFragment( Token nextToken )
+    public boolean isNewFragment( OffsetAttribute nextToken )
     {
         // text: /org/sonatype/...
         // tokens: org sonatype

--- a/indexer-core/src/main/java/org/apache/maven/index/StoredNotAnalyzedFieldType.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/StoredNotAnalyzedFieldType.java
@@ -1,0 +1,32 @@
+package org.apache.maven.index;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0    
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StringField;
+
+public class StoredNotAnalyzedFieldType extends FieldType {
+
+    public StoredNotAnalyzedFieldType() {
+        super(StringField.TYPE_STORED);
+        this.setOmitNorms(false);
+    }
+
+}

--- a/indexer-core/src/main/java/org/apache/maven/index/StoredNotIndexedFieldType.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/StoredNotIndexedFieldType.java
@@ -1,0 +1,33 @@
+package org.apache.maven.index;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0    
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexOptions;
+
+public class StoredNotIndexedFieldType extends FieldType {
+
+    public StoredNotIndexedFieldType() {
+        super(StringField.TYPE_STORED);
+        this.setIndexOptions(IndexOptions.NONE);
+    }
+
+}

--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
@@ -36,6 +36,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.FieldTypeFactory;
 import org.codehaus.plexus.util.FileUtils;
 
 public class IndexUtils
@@ -147,12 +148,12 @@ public class IndexUtils
         Document document = new Document();
 
         // unique key
-        document.add( new Field( ArtifactInfo.UINFO, ai.getUinfo(), Field.Store.YES, Field.Index.NOT_ANALYZED ) );
+        document.add( new Field( ArtifactInfo.UINFO, ai.getUinfo(), FieldTypeFactory.getStoredNotAnalyzedFieldType()) );
 
         if ( updateLastModified || doc.getField( ArtifactInfo.LAST_MODIFIED ) == null )
         {
             document.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-                Long.toString( System.currentTimeMillis() ), Field.Store.YES, Field.Index.NO ) );
+                Long.toString( System.currentTimeMillis() ), FieldTypeFactory.getStoredNotIndexedFieldType()) );
         }
         else
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
@@ -63,7 +63,8 @@ public class NexusIndexWriter
         // default open mode is CreateOrAppend which suits us
         config.setRAMBufferSizeMB( 2.0 ); // old default
         config.setMergeScheduler( new SerialMergeScheduler() ); // merging serially
-        config.setWriteLockTimeout(IndexWriterConfig.WRITE_LOCK_TIMEOUT);
+        //config.setWriteLockTimeout(IndexWriterConfig.WRITE_LOCK_TIMEOUT);
+        //not a good idea -  see https://lucene.apache.org/core/5_5_0/core/org/apache/lucene/store/SleepingLockWrapper.html
         return config;
     }
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/JarFileContentsIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/JarFileContentsIndexCreator.java
@@ -1,5 +1,11 @@
 package org.apache.maven.index.creator;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,15 +27,9 @@ package org.apache.maven.index.creator;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.TextField;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -52,7 +52,7 @@ public class JarFileContentsIndexCreator
     public static final String ID = "jarContent";
 
     public static final IndexerField FLD_CLASSNAMES = new IndexerField( MAVEN.CLASSNAMES, IndexerFieldVersion.V3,
-        "classnames", "Artifact Classes (tokenized)", Store.NO, Index.ANALYZED );
+        "classnames", "Artifact Classes (tokenized)", TextField.TYPE_NOT_STORED );
 
     /**
      * NexusAnalyzer makes exception with this field only, to keep backward compatibility with old consumers of
@@ -60,7 +60,7 @@ public class JarFileContentsIndexCreator
      * registered BEFORE FLD_CLASSNAMES_KW!
      */
     public static final IndexerField FLD_CLASSNAMES_KW = new IndexerField( MAVEN.CLASSNAMES, IndexerFieldVersion.V1,
-        "c", "Artifact Classes (tokenized on newlines only)", Store.YES, Index.ANALYZED );
+        "c", "Artifact Classes (tokenized on newlines only)", TextField.TYPE_STORED );
 
     public JarFileContentsIndexCreator()
     {

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
@@ -1,5 +1,14 @@
 package org.apache.maven.index.creator;
 
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,20 +30,12 @@ package org.apache.maven.index.creator;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.TextField;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.FieldTypeFactory;
 import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.IndexerFieldVersion;
 import org.apache.maven.index.MAVEN;
@@ -61,10 +62,10 @@ public class MavenPluginArtifactInfoIndexCreator
     private static final String MAVEN_PLUGIN_PACKAGING = "maven-plugin";
 
     public static final IndexerField FLD_PLUGIN_PREFIX = new IndexerField( MAVEN.PLUGIN_PREFIX, IndexerFieldVersion.V1,
-        "px", "MavenPlugin prefix (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "px", "MavenPlugin prefix (as keyword, stored)", FieldTypeFactory.getStoredNotAnalyzedFieldType() );
 
     public static final IndexerField FLD_PLUGIN_GOALS = new IndexerField( MAVEN.PLUGIN_GOALS, IndexerFieldVersion.V1,
-        "gx", "MavenPlugin goals (as keyword, stored)", Store.YES, Index.ANALYZED );
+        "gx", "MavenPlugin goals (as keyword, stored)", TextField.TYPE_STORED);
 
     public MavenPluginArtifactInfoIndexCreator()
     {

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/MinimalArtifactInfoIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/MinimalArtifactInfoIndexCreator.java
@@ -1,5 +1,10 @@
 package org.apache.maven.index.creator;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,26 +26,26 @@ package org.apache.maven.index.creator;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
-import org.apache.maven.index.*;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.TextField;
 import org.apache.maven.index.ArtifactAvailability;
+import org.apache.maven.index.ArtifactContext;
+import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.FieldTypeFactory;
+import org.apache.maven.index.IndexerField;
+import org.apache.maven.index.IndexerFieldVersion;
+import org.apache.maven.index.MAVEN;
+import org.apache.maven.index.NEXUS;
 import org.apache.maven.index.artifact.Gav;
-import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.locator.JavadocLocator;
 import org.apache.maven.index.locator.Locator;
 import org.apache.maven.index.locator.Sha1Locator;
 import org.apache.maven.index.locator.SignatureLocator;
 import org.apache.maven.index.locator.SourcesLocator;
 import org.apache.maven.model.Model;
-import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -64,46 +69,46 @@ public class MinimalArtifactInfoIndexCreator
      * Info: packaging, lastModified, size, sourcesExists, javadocExists, signatureExists. Stored, not indexed.
      */
     public static final IndexerField FLD_INFO = new IndexerField( NEXUS.INFO, IndexerFieldVersion.V1, "i",
-        "Artifact INFO (not indexed, stored)", Store.YES, Index.NO );
+        "Artifact INFO (not indexed, stored)", FieldTypeFactory.getStoredNotIndexedFieldType() );
 
     public static final IndexerField FLD_GROUP_ID_KW = new IndexerField( MAVEN.GROUP_ID, IndexerFieldVersion.V1, "g",
-        "Artifact GroupID (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact GroupID (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_GROUP_ID = new IndexerField( MAVEN.GROUP_ID, IndexerFieldVersion.V3,
-        "groupId", "Artifact GroupID (tokenized)", Store.NO, Index.ANALYZED );
+        "groupId", "Artifact GroupID (tokenized)", TextField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_ARTIFACT_ID_KW = new IndexerField( MAVEN.ARTIFACT_ID, IndexerFieldVersion.V1,
-        "a", "Artifact ArtifactID (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "a", "Artifact ArtifactID (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_ARTIFACT_ID = new IndexerField( MAVEN.ARTIFACT_ID, IndexerFieldVersion.V3,
-        "artifactId", "Artifact ArtifactID (tokenized)", Store.NO, Index.ANALYZED );
+        "artifactId", "Artifact ArtifactID (tokenized)", TextField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_VERSION_KW = new IndexerField( MAVEN.VERSION, IndexerFieldVersion.V1, "v",
-        "Artifact Version (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact Version (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_VERSION = new IndexerField( MAVEN.VERSION, IndexerFieldVersion.V3, "version",
-        "Artifact Version (tokenized)", Store.NO, Index.ANALYZED );
+        "Artifact Version (tokenized)", TextField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_PACKAGING = new IndexerField( MAVEN.PACKAGING, IndexerFieldVersion.V1, "p",
-        "Artifact Packaging (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact Packaging (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_EXTENSION = new IndexerField( MAVEN.EXTENSION, IndexerFieldVersion.V1, "e",
-        "Artifact extension (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact extension (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_CLASSIFIER = new IndexerField( MAVEN.CLASSIFIER, IndexerFieldVersion.V1, "l",
-        "Artifact classifier (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact classifier (as keyword)", StringField.TYPE_NOT_STORED );
 
     public static final IndexerField FLD_NAME = new IndexerField( MAVEN.NAME, IndexerFieldVersion.V1, "n",
-        "Artifact name (tokenized, stored)", Store.YES, Index.ANALYZED );
+        "Artifact name (tokenized, stored)", TextField.TYPE_STORED );
 
     public static final IndexerField FLD_DESCRIPTION = new IndexerField( MAVEN.DESCRIPTION, IndexerFieldVersion.V1,
-        "d", "Artifact description (tokenized, stored)", Store.YES, Index.ANALYZED );
+        "d", "Artifact description (tokenized, stored)", TextField.TYPE_STORED );
 
     public static final IndexerField FLD_LAST_MODIFIED = new IndexerField( MAVEN.LAST_MODIFIED, IndexerFieldVersion.V1,
-        "m", "Artifact last modified (not indexed, stored)", Store.YES, Index.NO );
+        "m", "Artifact last modified (not indexed, stored)", FieldTypeFactory.getStoredNotIndexedFieldType() );
 
     public static final IndexerField FLD_SHA1 = new IndexerField( MAVEN.SHA1, IndexerFieldVersion.V1, "1",
-        "Artifact SHA1 checksum (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "Artifact SHA1 checksum (as keyword, stored)", FieldTypeFactory.getStoredNotAnalyzedFieldType() );
 
     private Locator jl = new JavadocLocator();
 
@@ -304,17 +309,16 @@ public class MinimalArtifactInfoIndexCreator
         // legacy!
         if ( ai.getPrefix() != null )
         {
-            doc.add( new Field( ArtifactInfo.PLUGIN_PREFIX, ai.getPrefix(), Field.Store.YES, Field.Index.NOT_ANALYZED ) );
+            doc.add( new Field( ArtifactInfo.PLUGIN_PREFIX, ai.getPrefix(), FieldTypeFactory.getStoredNotAnalyzedFieldType()) );
         }
 
         if ( ai.getGoals() != null )
         {
-            doc.add( new Field( ArtifactInfo.PLUGIN_GOALS, ArtifactInfo.lst2str( ai.getGoals() ), Field.Store.YES,
-                Field.Index.NO ) );
+            doc.add( new Field( ArtifactInfo.PLUGIN_GOALS, ArtifactInfo.lst2str( ai.getGoals() ), FieldTypeFactory.getStoredNotIndexedFieldType()) );
         }
 
         doc.removeField( ArtifactInfo.GROUP_ID );
-        doc.add( new Field( ArtifactInfo.GROUP_ID, ai.getGroupId(), Field.Store.NO, Field.Index.NOT_ANALYZED ) );
+        doc.add( new Field( ArtifactInfo.GROUP_ID, ai.getGroupId(), StringField.TYPE_NOT_STORED ) );
     }
 
     public boolean updateArtifactInfo( Document doc, ArtifactInfo ai )

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/OsgiArtifactIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/OsgiArtifactIndexCreator.java
@@ -24,8 +24,10 @@ import javax.inject.Singleton;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.FieldTypeFactory;
 import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.IndexerFieldVersion;
 import org.apache.maven.index.OSGI;
@@ -71,88 +73,84 @@ public class OsgiArtifactIndexCreator
     public static final String ID = "osgi-metadatas";
     public static final IndexerField FLD_SHA256 =
             new IndexerField(OSGI.SHA256, IndexerFieldVersion.V4, "sha256", "SHA-256 (not analyzed, stored)",
-                    Field.Store.YES, Field.Index.NOT_ANALYZED);
+                    FieldTypeFactory.getStoredNotAnalyzedFieldType());
     private static final String BSN = "Bundle-SymbolicName";
 
     public static final IndexerField FLD_BUNDLE_SYMBOLIC_NAME =
         new IndexerField( OSGI.SYMBOLIC_NAME, IndexerFieldVersion.V4, BSN, "Bundle-SymbolicName (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          TextField.TYPE_STORED);
 
 
     private static final String BV = "Bundle-Version";
 
     public static final IndexerField FLD_BUNDLE_VERSION =
-        new IndexerField( OSGI.VERSION, IndexerFieldVersion.V4, BV, "Bundle-Version (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.VERSION, IndexerFieldVersion.V4, BV, "Bundle-Version (indexed, stored)", TextField.TYPE_STORED);
 
 
     private static final String BEP = "Export-Package";
 
     public static final IndexerField FLD_BUNDLE_EXPORT_PACKAGE =
         new IndexerField( OSGI.EXPORT_PACKAGE, IndexerFieldVersion.V4, BEP, "Export-Package (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+        		TextField.TYPE_STORED );
     @Deprecated
     private static final String BES = "Export-Service";
     @Deprecated
     public static final IndexerField FLD_BUNDLE_EXPORT_SERVIVE =
         new IndexerField( OSGI.EXPORT_SERVICE, IndexerFieldVersion.V4, BES, "Export-Service (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+        		TextField.TYPE_STORED );
 
 
     private static final String BD = "Bundle-Description";
 
     public static final IndexerField FLD_BUNDLE_DESCRIPTION =
         new IndexerField( OSGI.DESCRIPTION, IndexerFieldVersion.V4, BD, "Bundle-Description (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+        		TextField.TYPE_STORED );
 
     private static final String BN = "Bundle-Name";
 
     public static final IndexerField FLD_BUNDLE_NAME =
-        new IndexerField( OSGI.NAME, IndexerFieldVersion.V4, BN, "Bundle-Name (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.NAME, IndexerFieldVersion.V4, BN, "Bundle-Name (indexed, stored)", TextField.TYPE_STORED );
 
     private static final String BL = "Bundle-License";
 
     public static final IndexerField FLD_BUNDLE_LICENSE =
-        new IndexerField( OSGI.LICENSE, IndexerFieldVersion.V4, BL, "Bundle-License (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.LICENSE, IndexerFieldVersion.V4, BL, "Bundle-License (indexed, stored)", TextField.TYPE_STORED );
 
     private static final String BDU = "Bundle-DocURL";
 
     public static final IndexerField FLD_BUNDLE_DOCURL =
-        new IndexerField( OSGI.DOCURL, IndexerFieldVersion.V4, BDU, "Bundle-DocURL (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.DOCURL, IndexerFieldVersion.V4, BDU, "Bundle-DocURL (indexed, stored)", TextField.TYPE_STORED );
 
     private static final String BIP = "Import-Package";
 
     public static final IndexerField FLD_BUNDLE_IMPORT_PACKAGE =
         new IndexerField( OSGI.IMPORT_PACKAGE, IndexerFieldVersion.V4, BIP, "Import-Package (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+        		TextField.TYPE_STORED );
 
 
     private static final String BRB = "Require-Bundle";
 
     public static final IndexerField FLD_BUNDLE_REQUIRE_BUNDLE =
         new IndexerField( OSGI.REQUIRE_BUNDLE, IndexerFieldVersion.V4, BRB, "Require-Bundle (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+        		TextField.TYPE_STORED );
     private static final String PROVIDE_CAPABILITY = "Provide-Capability";
     public static final IndexerField FLD_BUNDLE_PROVIDE_CAPABILITY =
             new IndexerField(OSGI.PROVIDE_CAPABILITY, IndexerFieldVersion.V4, PROVIDE_CAPABILITY, "Provide-Capability (indexed, stored)",
-                    Field.Store.YES, Field.Index.ANALYZED);
+            		TextField.TYPE_STORED);
     private static final String REQUIRE_CAPABILITY = "Require-Capability";
     public static final IndexerField FLD_BUNDLE_REQUIRE_CAPABILITY =
             new IndexerField(OSGI.REQUIRE_CAPABILITY, IndexerFieldVersion.V4, REQUIRE_CAPABILITY, "Require-Capability (indexed, stored)",
-                    Field.Store.YES, Field.Index.ANALYZED);
+            		TextField.TYPE_STORED);
     private static final String FRAGMENT_HOST = "Fragment-Host";
     public static final IndexerField FLD_BUNDLE_FRAGMENT_HOST =
             new IndexerField(OSGI.FRAGMENT_HOST, IndexerFieldVersion.V4, FRAGMENT_HOST, "Fragment-Host (indexed, stored)",
-                    Field.Store.YES, Field.Index.ANALYZED);
+            		TextField.TYPE_STORED);
 
     private static final String BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT = "Bundle-RequiredExecutionEnvironment";
     public static final IndexerField FLD_BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT =
             new IndexerField(OSGI.BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT, IndexerFieldVersion.V4, BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT,
                     "Bundle-RequiredExecutionEnvironment (indexed, stored)",
-                    Field.Store.YES, Field.Index.ANALYZED);
+                    TextField.TYPE_STORED);
 
 
 

--- a/indexer-core/src/main/java/org/apache/maven/index/treeview/DefaultIndexTreeView.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/treeview/DefaultIndexTreeView.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.Query;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.Field;
@@ -517,21 +518,21 @@ public class DefaultIndexTreeView
             versionQ = getIndexer().constructQuery( MAVEN.VERSION, new SourcedSearchExpression( v ) );
         }
 
-        BooleanQuery q = new BooleanQuery();
+        Builder qb = new BooleanQuery.Builder();
 
-        q.add( new BooleanClause( groupIdQ, BooleanClause.Occur.MUST ) );
+        qb.add( new BooleanClause( groupIdQ, BooleanClause.Occur.MUST ) );
 
         if ( artifactIdQ != null )
         {
-            q.add( new BooleanClause( artifactIdQ, BooleanClause.Occur.MUST ) );
+            qb.add( new BooleanClause( artifactIdQ, BooleanClause.Occur.MUST ) );
         }
 
         if ( versionQ != null )
         {
-            q.add( new BooleanClause( versionQ, BooleanClause.Occur.MUST ) );
+            qb.add( new BooleanClause( versionQ, BooleanClause.Occur.MUST ) );
         }
 
-        IteratorSearchRequest searchRequest = new IteratorSearchRequest( q, request.getArtifactInfoFilter() );
+        IteratorSearchRequest searchRequest = new IteratorSearchRequest( qb.build(), request.getArtifactInfoFilter() );
 
         searchRequest.getContexts().add( request.getIndexingContext() );
 

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -271,7 +271,7 @@ public class DefaultIndexUpdater
 
                 if ( !filter.accept( d ) )
                 {
-                    boolean success = w.tryDeleteDocument(r, i);
+                    long success = w.tryDeleteDocument(r, i);
                     //FIXME handle deletion failure
                 }
             }

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -27,19 +27,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UTFDataFormatException;
 import java.util.Date;
-import java.util.zip.GZIPInputStream;
-
-import com.google.common.base.Strings;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.zip.GZIPInputStream;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.FieldType;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.context.IndexUtils;
 import org.apache.maven.index.context.IndexingContext;
+
+import com.google.common.base.Strings;
 
 /**
  * An index data reader used to parse transfer index format.
@@ -176,23 +176,20 @@ public class IndexDataReader
     {
         int flags = dis.read();
 
-        Index index = Index.NO;
+        FieldType  fieldType = new FieldType();
         if ( ( flags & IndexDataWriter.F_INDEXED ) > 0 )
         {
             boolean isTokenized = ( flags & IndexDataWriter.F_TOKENIZED ) > 0;
-            index = isTokenized ? Index.ANALYZED : Index.NOT_ANALYZED;
+            fieldType.setTokenized(isTokenized);
         }
 
-        Store store = Store.NO;
-        if ( ( flags & IndexDataWriter.F_STORED ) > 0 )
-        {
-            store = Store.YES;
-        }
+        boolean isStored = ( flags & IndexDataWriter.F_STORED ) > 0;
+        fieldType.setStored(isStored);
 
         String name = dis.readUTF();
         String value = readUTF( dis );
 
-        return new Field( name, value, store, index );
+		return new Field( name, value, fieldType );
     }
 
     private static String readUTF( DataInput in )

--- a/indexer-core/src/test/java/org/apache/maven/index/DefaultIndexNexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/DefaultIndexNexusIndexerTest.java
@@ -29,11 +29,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.lucene.index.Term;
-import org.apache.lucene.search.FilteredQuery;
+import org.apache.lucene.search.BooleanClause.Occur;
+import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryWrapperFilter;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
@@ -75,7 +75,12 @@ public class DefaultIndexNexusIndexerTest
         // bq.add(new PrefixQuery(new Term(ArtifactInfo.GROUP_ID, term + "*")), Occur.SHOULD);
         // bq.add(new PrefixQuery(new Term(ArtifactInfo.ARTIFACT_ID, term + "*")), Occur.SHOULD);
         TermQuery tq = new TermQuery( new Term( ArtifactInfo.PACKAGING, "maven-plugin" ) );
-        Query query = new FilteredQuery( tq, new QueryWrapperFilter( bq ) );
+      //see https://lucene.apache.org/core/5_4_0/core/org/apache/lucene/search/FilteredQuery.html
+        org.apache.lucene.search.BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+        
+        bqb.add(tq, Occur.MUST);
+        bqb.add(bq, Occur.FILTER);
+        Query query = bqb.build();
 
         FlatSearchResponse response = nexusIndexer.searchFlat( new FlatSearchRequest( query ) );
 
@@ -244,7 +249,12 @@ public class DefaultIndexNexusIndexerTest
 
         Query bq = new PrefixQuery( new Term( ArtifactInfo.GROUP_ID, term ) );
         TermQuery tq = new TermQuery( new Term( ArtifactInfo.PACKAGING, "maven-archetype" ) );
-        Query query = new FilteredQuery( tq, new QueryWrapperFilter( bq ) );
+      //see https://lucene.apache.org/core/5_4_0/core/org/apache/lucene/search/FilteredQuery.html
+        org.apache.lucene.search.BooleanQuery.Builder bqb = new BooleanQuery.Builder();
+        
+        bqb.add(tq, Occur.MUST);
+        bqb.add(bq, Occur.FILTER);
+        Query query = bqb.build();
 
         FlatSearchResponse response = nexusIndexer.searchFlat( new FlatSearchRequest( query ) );
 

--- a/indexer-core/src/test/java/org/apache/maven/index/Nexus3881NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/Nexus3881NexusIndexerTest.java
@@ -25,6 +25,7 @@ import junit.framework.Assert;
 
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.Query;
 
 public class Nexus3881NexusIndexerTest
@@ -47,11 +48,11 @@ public class Nexus3881NexusIndexerTest
         Query q1 = nexusIndexer.constructQuery( MAVEN.GROUP_ID, "solution", SearchType.SCORED );
         Query q2 = nexusIndexer.constructQuery( MAVEN.ARTIFACT_ID, "solution", SearchType.SCORED );
 
-        BooleanQuery bq = new BooleanQuery();
-        bq.add( q1, Occur.SHOULD );
-        bq.add( q2, Occur.SHOULD );
+        Builder bqb = new BooleanQuery.Builder();
+        bqb.add( q1, Occur.SHOULD );
+        bqb.add( q2, Occur.SHOULD );
 
-        IteratorSearchRequest request = new IteratorSearchRequest( bq );
+        IteratorSearchRequest request = new IteratorSearchRequest( bqb.build() );
         request.setLuceneExplain( true );
         
         IteratorSearchResponse response = nexusIndexer.searchIterator( request );

--- a/indexer-core/src/test/java/org/apache/maven/index/SearchWithAnEmptyIndexTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/SearchWithAnEmptyIndexTest.java
@@ -21,6 +21,7 @@ package org.apache.maven.index;
 
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexingContext;
@@ -89,13 +90,13 @@ public class SearchWithAnEmptyIndexTest
 
         try
         {
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
+            qb.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
                                                 new StringSearchExpression( "org.apache.karaf.features.command" ) ),
                    BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             assertEquals( 2, nexusIndexer.getIndexingContexts().values().size() );
             request.setContexts( Arrays.asList( nexusIndexer.getIndexingContexts().get( INDEX_ID2 ),
                                                 nexusIndexer.getIndexingContexts().get( INDEX_ID1 ) ) );
@@ -104,13 +105,13 @@ public class SearchWithAnEmptyIndexTest
 
             assertEquals( 1, response.getResults().size() );
 
-            q = new BooleanQuery();
+            qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
+            qb.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
                                                 new StringSearchExpression( "org.apache.karaf.features.core" ) ),
                    BooleanClause.Occur.MUST );
 
-            request = new FlatSearchRequest( q );
+            request = new FlatSearchRequest( qb.build() );
             request.setContexts( new ArrayList( nexusIndexer.getIndexingContexts().values() ) );
 
             response = nexusIndexer.searchFlat( request );
@@ -119,20 +120,20 @@ public class SearchWithAnEmptyIndexTest
 
             String term = "org.apache.karaf.features";
 
-            q = new BooleanQuery();
+            qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( MAVEN.GROUP_ID, new StringSearchExpression( term ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.GROUP_ID, new StringSearchExpression( term ) ),
                    BooleanClause.Occur.SHOULD );
-            q.add( nexusIndexer.constructQuery( MAVEN.ARTIFACT_ID, new StringSearchExpression( term ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.ARTIFACT_ID, new StringSearchExpression( term ) ),
                    BooleanClause.Occur.SHOULD );
-            q.add( nexusIndexer.constructQuery( MAVEN.VERSION, new StringSearchExpression( term ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.VERSION, new StringSearchExpression( term ) ),
                    BooleanClause.Occur.SHOULD );
-            q.add( nexusIndexer.constructQuery( MAVEN.PACKAGING, new StringSearchExpression( term ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.PACKAGING, new StringSearchExpression( term ) ),
                    BooleanClause.Occur.SHOULD );
-            q.add( nexusIndexer.constructQuery( MAVEN.CLASSNAMES, new StringSearchExpression( term ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.CLASSNAMES, new StringSearchExpression( term ) ),
                    BooleanClause.Occur.SHOULD );
 
-            request = new FlatSearchRequest( q );
+            request = new FlatSearchRequest( qb.build() );
             request.setContexts( new ArrayList( nexusIndexer.getIndexingContexts().values() ) );
 
             response = nexusIndexer.searchFlat( request );
@@ -173,18 +174,18 @@ public class SearchWithAnEmptyIndexTest
 
         try
         {
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( MAVEN.GROUP_ID, new StringSearchExpression( "commons-cli" ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.GROUP_ID, new StringSearchExpression( "commons-cli" ) ),
                    BooleanClause.Occur.MUST );
 
-            q.add( nexusIndexer.constructQuery( MAVEN.PACKAGING, new StringSearchExpression( "jar" ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.PACKAGING, new StringSearchExpression( "jar" ) ),
                    BooleanClause.Occur.MUST );
 
-            q.add( nexusIndexer.constructQuery( MAVEN.CLASSIFIER, new StringSearchExpression( "sources" ) ),
+            qb.add( nexusIndexer.constructQuery( MAVEN.CLASSIFIER, new StringSearchExpression( "sources" ) ),
                    BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             assertEquals( 2, nexusIndexer.getIndexingContexts().values().size() );
             request.setContexts( Arrays.asList( nexusIndexer.getIndexingContexts().get( INDEX_ID2 ),
                                                 nexusIndexer.getIndexingContexts().get( INDEX_ID1 ) ) );

--- a/indexer-core/src/test/java/org/apache/maven/index/creator/OsgiArtifactIndexCreatorTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/creator/OsgiArtifactIndexCreatorTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.FlatSearchRequest;
@@ -193,25 +194,25 @@ public class OsgiArtifactIndexCreatorTest
         {
             indexOSGIRepo();
 
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
+            qb.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
                                                 new StringSearchExpression( "org.apache.karaf.features.command" ) ),
                    BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             FlatSearchResponse response = nexusIndexer.searchFlat( request );
 
             // here only one results !
             assertEquals( 1, response.getResults().size() );
 
-            q = new BooleanQuery();
+            qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
+            qb.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
                                                 new StringSearchExpression( "org.apache.karaf.features.core" ) ),
                    BooleanClause.Occur.MUST );
 
-            request = new FlatSearchRequest( q );
+            request = new FlatSearchRequest( qb.build() );
             response = nexusIndexer.searchFlat( request );
 
             // here two results !
@@ -232,16 +233,16 @@ public class OsgiArtifactIndexCreatorTest
         try
         {
 
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
+            qb.add( nexusIndexer.constructQuery( OSGI.SYMBOLIC_NAME,
                                                 new StringSearchExpression( "org.apache.karaf.features.core" ) ),
                    BooleanClause.Occur.MUST );
 
-            q.add( nexusIndexer.constructQuery( OSGI.VERSION, new StringSearchExpression( "2.2.1" ) ),
+            qb.add( nexusIndexer.constructQuery( OSGI.VERSION, new StringSearchExpression( "2.2.1" ) ),
                    BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             FlatSearchResponse response = nexusIndexer.searchFlat( request );
 
             // here only one results as we use version
@@ -261,13 +262,13 @@ public class OsgiArtifactIndexCreatorTest
 
         try {
 
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
 
-            q.add(nexusIndexer.constructQuery(OSGI.SHA256, new StringSearchExpression(CORE_4_1_0_SHA256)),
+            qb.add(nexusIndexer.constructQuery(OSGI.SHA256, new StringSearchExpression(CORE_4_1_0_SHA256)),
                     BooleanClause.Occur.MUST);
 
-            FlatSearchRequest request = new FlatSearchRequest(q);
+            FlatSearchRequest request = new FlatSearchRequest(qb.build());
             FlatSearchResponse response = nexusIndexer.searchFlat(request);
 
             // here only one results as we use version
@@ -291,12 +292,12 @@ public class OsgiArtifactIndexCreatorTest
         try
         {
 
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.EXPORT_PACKAGE, new StringSearchExpression(
+            qb.add( nexusIndexer.constructQuery( OSGI.EXPORT_PACKAGE, new StringSearchExpression(
                 "org.apache.karaf.features.command.completers" ) ), BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             FlatSearchResponse response = nexusIndexer.searchFlat( request );
 
             //System.out.println("results with export package query " + response.getResults() );
@@ -337,12 +338,12 @@ public class OsgiArtifactIndexCreatorTest
         try
         {
 
-            BooleanQuery q = new BooleanQuery();
+            Builder qb = new BooleanQuery.Builder();
 
-            q.add( nexusIndexer.constructQuery( OSGI.EXPORT_SERVICE, new StringSearchExpression(
+            qb.add( nexusIndexer.constructQuery( OSGI.EXPORT_SERVICE, new StringSearchExpression(
                 "org.apache.felix.bundlerepository.RepositoryAdmin" ) ), BooleanClause.Occur.MUST );
 
-            FlatSearchRequest request = new FlatSearchRequest( q );
+            FlatSearchRequest request = new FlatSearchRequest( qb.build() );
             FlatSearchResponse response = nexusIndexer.searchFlat( request );
 
             //System.out.println("results with export package query " + response.getResults() );

--- a/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
+++ b/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/indexer/examples/indexing/RepositoryIndexer.java
@@ -23,6 +23,7 @@ import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.queryparser.classic.MultiFieldQueryParser;
 import org.apache.lucene.queryparser.classic.ParseException;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BooleanQuery.Builder;
 import org.apache.lucene.search.Query;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
@@ -116,45 +117,45 @@ public class RepositoryIndexer
                                      final String packaging, final String classifier )
         throws IOException
     {
-        final BooleanQuery query = new BooleanQuery();
+        final Builder queryBuilder = new BooleanQuery.Builder();
 
         if ( groupId != null )
         {
-            query.add( getIndexer().constructQuery( MAVEN.GROUP_ID, new SourcedSearchExpression( groupId ) ), MUST );
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.GROUP_ID, new SourcedSearchExpression( groupId ) ), MUST );
         }
 
         if ( artifactId != null )
         {
-            query.add( getIndexer().constructQuery( MAVEN.ARTIFACT_ID, new SourcedSearchExpression( artifactId ) ),
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.ARTIFACT_ID, new SourcedSearchExpression( artifactId ) ),
                        MUST );
         }
 
         if ( version != null )
         {
-            query.add( getIndexer().constructQuery( MAVEN.VERSION, new SourcedSearchExpression( version ) ), MUST );
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.VERSION, new SourcedSearchExpression( version ) ), MUST );
         }
 
         if ( packaging != null )
         {
-            query.add( getIndexer().constructQuery( MAVEN.PACKAGING, new SourcedSearchExpression( packaging ) ), MUST );
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.PACKAGING, new SourcedSearchExpression( packaging ) ), MUST );
         }
         else
         {
             // Fallback to jar
-            query.add( getIndexer().constructQuery( MAVEN.PACKAGING, new SourcedSearchExpression( "jar" ) ), MUST );
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.PACKAGING, new SourcedSearchExpression( "jar" ) ), MUST );
         }
 
         if ( classifier != null )
         {
-            query.add( getIndexer().constructQuery( MAVEN.CLASSIFIER, new SourcedSearchExpression( classifier ) ),
+            queryBuilder.add( getIndexer().constructQuery( MAVEN.CLASSIFIER, new SourcedSearchExpression( classifier ) ),
                        MUST );
         }
 
         LOGGER.debug( "Executing search query: {}; ctx id: {}; idx dir: {}",
-                      new String[]{ query.toString(), indexingContext.getId(),
+                      new String[]{ queryBuilder.toString(), indexingContext.getId(),
                           indexingContext.getIndexDirectory().toString() } );
 
-        final FlatSearchResponse response = getIndexer().searchFlat( new FlatSearchRequest( query, indexingContext ) );
+        final FlatSearchResponse response = getIndexer().searchFlat( new FlatSearchRequest( queryBuilder.build(), indexingContext ) );
 
         LOGGER.info( "Hit count: {}", response.getReturnedHitsCount() );
 
@@ -198,14 +199,14 @@ public class RepositoryIndexer
     public Set<ArtifactInfo> searchBySHA1( final String checksum )
         throws IOException
     {
-        final BooleanQuery query = new BooleanQuery();
-        query.add( getIndexer().constructQuery( MAVEN.SHA1, new SourcedSearchExpression( checksum ) ), MUST );
+        final Builder queryBuilder = new BooleanQuery.Builder();
+        queryBuilder.add( getIndexer().constructQuery( MAVEN.SHA1, new SourcedSearchExpression( checksum ) ), MUST );
 
         LOGGER.debug( "Executing search query: {}; ctx id: {}; idx dir: {}",
-                      new String[]{ query.toString(), indexingContext.getId(),
+                      new String[]{ queryBuilder.toString(), indexingContext.getId(),
                           indexingContext.getIndexDirectory().toString() } );
 
-        final FlatSearchResponse response = getIndexer().searchFlat( new FlatSearchRequest( query, indexingContext ) );
+        final FlatSearchResponse response = getIndexer().searchFlat( new FlatSearchRequest( queryBuilder.build(), indexingContext ) );
 
         LOGGER.info( "Hit count: {}", response.getReturnedHitsCount() );
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,12 +83,12 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
 
     <eclipse-sisu.version>0.2.1</eclipse-sisu.version>
     <sisu-guice.version>3.2.2</sisu-guice.version>
 
-    <lucene.version>5.5.4</lucene.version>
+    <lucene.version>7.0.0</lucene.version>
     <maven.version>3.0.5</maven.version>
     <aether.version>1.0.0.v20140518</aether.version>
 


### PR DESCRIPTION
Now that Lucene 7 is released I abandoned the 6.1 migration PR and created this new one which takes it straight to 7.

One thing to note is that this might need the enforced JDK to be bumped to 8.