### PR TITLE
Excluding additional dependencies from shaded jar

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -254,6 +254,11 @@ under the License.
                   <exclude>org.apache.maven.wagon:*</exclude>
                   <exclude>org.codehaus.*:*</exclude>
                   <exclude>de.schlichtherle.truezip:*</exclude>
+                  <exclude>org.apache.maven.resolver:*</exclude>
+                  <exclude>org.apache.maven:maven-model</exclude>
+                  <exclude>org.apache.commons:*</exclude>
+                  <exclude>org.bouncycastle:*</exclude>
+                  <exclude>aopalliance:*</exclude>
                 </excludes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
There are classes included in the shaded_lucene jar file from dependent artifacts. To avoid conflicts with other packages and their maven dependencies there should only be the relocated packages and the maven indexer packages in the jar.
Dependencies that are not relocated should be still loaded via the dependent jar files. 