### PR TITLE
Removing shading for maven model packages

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -237,10 +237,6 @@ under the License.
                   <pattern>org.apache.commons.compress</pattern>
                   <shadedPattern>org.apache.maven.index_shaded.lucene</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.apache.maven.model</pattern>
-                  <shadedPattern>org.apache.maven.index_shaded.maven</shadedPattern>
-                </relocation>
               </relocations>
               <artifactSet>
                 <excludes>


### PR DESCRIPTION
Found an issue with referenced objects in maven model packages in the shaded library (references to classes in a shaded package that does not exist). I think this update should fix it. 