### PR TITLE
Reset the correct stream in IndexDataReader

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -65,9 +65,8 @@ public class IndexDataReader
         }
         else
         {
-            BufferedInputStream bis = new BufferedInputStream( is, 1024 * 8 );
-            bis.reset();
-            data = bis;
+            is.reset();
+            data = new BufferedInputStream( is, 1024 * 8 );
         }
 
         this.dis = new DataInputStream( data );


### PR DESCRIPTION
Fixes IOException being thrown everytime when the Wagon has performed automatic decompression.

In the original code, `bis.reset()` is called and it throws an IOException, because it is the wrong stream to reset.