### PR TITLE
Correct errors with optional scope in dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,13 +115,13 @@ under the License.
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>1.2.3</version>
-        <scope>optional</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>1.2.3</version>
-        <scope>optional</scope>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <!-- This dependency is required in order to intercept Spring logging and handle it through Logback + SLF4J,
@@ -129,7 +129,7 @@ under the License.
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>1.7.25</version>
-        <scope>optional</scope>
+        <optional>true</optional>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
fixes warnings

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.maven.indexer:maven-indexer:pom:6.0.1-SNAPSHOT
[WARNING] 'dependencyManagement.dependencies.dependency.scope' for ch.qos.logback:logback-classic:jar must be one of [provided, compile, runtime, test, system, import] but is 'optional'. @ line 118, column 16
[WARNING] 'dependencyManagement.dependencies.dependency.scope' for ch.qos.logback:logback-core:jar must be one of [provided, compile, runtime, test, system, import] but is 'optional'. @ line 124, column 16
[WARNING] 'dependencyManagement.dependencies.dependency.scope' for org.slf4j:jcl-over-slf4j:jar must be one of [provided, compile, runtime, test, system, import] but is 'optional'. @ line 132, column 16
[WARNING]
```