### PR TITLE
Eliminate use of deprecated Lucene API

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
@@ -28,8 +28,7 @@ import java.util.List;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StoredField;
 import org.apache.maven.index.artifact.Gav;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexingContext;
@@ -166,10 +165,10 @@ public class ArtifactContext
         Document doc = new Document();
 
         // unique key
-        doc.add( new Field( ArtifactInfo.UINFO, getArtifactInfo().getUinfo(), Store.YES, Index.NOT_ANALYZED ) );
+        doc.add( new Field( ArtifactInfo.UINFO, getArtifactInfo().getUinfo(), IndexerField.KEYWORD_STORED ) );
 
-        doc.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-            Long.toString( System.currentTimeMillis() ), Store.YES, Index.NO ) );
+        doc.add( new StoredField( ArtifactInfo.LAST_MODIFIED, //
+            Long.toString( System.currentTimeMillis() ) ) );
 
         for ( IndexCreator indexCreator : context.getIndexCreators() )
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfo.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfo.java
@@ -336,9 +336,6 @@ public class ArtifactInfo
 
     private final transient VersionScheme versionScheme;
 
-    private String uinfo = null;
-
-
     public ArtifactInfo()
     {
         versionScheme = new GenericVersionScheme();

--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfoRecord.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfoRecord.java
@@ -22,8 +22,7 @@ package org.apache.maven.index;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StoredField;
 
 /**
  * Pulling out ArtifactInfo, clearing up. TBD. This gonna be extensible "map-like" class with fields.
@@ -53,14 +52,13 @@ public class ArtifactInfoRecord
      * Unique groupId, artifactId, version, classifier, extension (or packaging). Stored, indexed untokenized
      */
     public static final IndexerField FLD_UINFO = new IndexerField( NEXUS.UINFO, IndexerFieldVersion.V1, "u",
-        "Artifact UINFO (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "Artifact UINFO (as keyword, stored)", IndexerField.KEYWORD_STORED );
 
     /**
      * Del: contains UINFO to mark record as deleted (needed for incremental updates!). The original document IS
      * removed, but this marker stays on index to note that fact.
      */
     public static final IndexerField FLD_DELETED = new IndexerField( NEXUS.DELETED, IndexerFieldVersion.V1, "del",
-        "Deleted field, will contain UINFO if document is deleted from index (not indexed, stored)", Store.YES,
-        Index.NO );
+        "Deleted field, will contain UINFO if document is deleted from index (not indexed, stored)", StoredField.TYPE );
 
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
@@ -160,7 +160,7 @@ public class DefaultIndexerEngine
                     indexSearcher.search(
                         new TermQuery( new Term( ArtifactInfo.UINFO, ac.getArtifactInfo().getUinfo() ) ), 2 );
 
-                if ( result.totalHits == 1 )
+                if ( result.totalHits.value == 1 )
                 {
                     return indexSearcher.doc( result.scoreDocs[0].doc );
                 }

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.Term;
@@ -100,9 +100,9 @@ public class DefaultIndexerEngine
             // add artifact deletion marker
             final Document doc = new Document();
 
-            doc.add( new Field( ArtifactInfo.DELETED, uinfo, Field.Store.YES, Field.Index.NO ) );
-            doc.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-                Long.toString( System.currentTimeMillis() ), Field.Store.YES, Field.Index.NO ) );
+            doc.add( new StoredField( ArtifactInfo.DELETED, uinfo ) );
+            doc.add( new StoredField( ArtifactInfo.LAST_MODIFIED, //
+                Long.toString( System.currentTimeMillis() ) ) );
 
             IndexWriter w = context.getIndexWriter();
             w.addDocument( doc );

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
@@ -212,7 +212,7 @@ public class DefaultScannerListener
         try
         {
             final IndexReader r = indexSearcher.getIndexReader();
-            Bits liveDocs = MultiFields.getLiveDocs( r );
+            Bits liveDocs = MultiBits.getLiveDocs( r );
 
             for ( int i = 0; i < r.maxDoc(); i++ )
             {
@@ -261,7 +261,7 @@ public class DefaultScannerListener
         {
             for ( String uinfo : uinfos )
             {
-                TopScoreDocCollector collector = TopScoreDocCollector.create( 1 );
+                TopScoreDocCollector collector = TopScoreDocCollector.create( 1, Integer.MAX_VALUE );
 
                 indexSearcher.search( new TermQuery( new Term( ArtifactInfo.UINFO, uinfo ) ), collector );
 

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
@@ -330,7 +330,7 @@ public class DefaultSearchEngine
         if ( AbstractSearchRequest.UNDEFINED != topHitCount )
         {
             // count is set, simply just execute it as-is
-            final TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount );
+            final TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount, Integer.MAX_VALUE );
 
             indexSearcher.search( query, hits );
 
@@ -342,7 +342,7 @@ public class DefaultSearchEngine
             topHitCount = 1000;
 
             // perform search
-            TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount );
+            TopScoreDocCollector hits = TopScoreDocCollector.create( topHitCount, Integer.MAX_VALUE );
             indexSearcher.search( query, hits );
 
             // check total hits against, does it fit?
@@ -361,7 +361,7 @@ public class DefaultSearchEngine
                 }
 
                 // redo all, but this time with correct numbers
-                hits = TopScoreDocCollector.create( topHitCount );
+                hits = TopScoreDocCollector.create( topHitCount, Integer.MAX_VALUE );
                 indexSearcher.search( query, hits );
             }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/OneLineFragmenter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/OneLineFragmenter.java
@@ -19,7 +19,6 @@ package org.apache.maven.index;
  * under the License.
  */
 
-import org.apache.lucene.analysis.Token;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.search.highlight.Fragmenter;
 
@@ -31,16 +30,6 @@ public class OneLineFragmenter
     public void start( String originalText )
     {
         setText( originalText );
-    }
-
-    public boolean isNewFragment( Token nextToken )
-    {
-        // text: /org/sonatype/...
-        // tokens: org sonatype
-        boolean result =
-            isNewline( getChar( nextToken.startOffset() - 1 ) ) || isNewline( getChar( nextToken.startOffset() - 2 ) );
-
-        return result;
     }
 
     protected boolean isNewline( char c )

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -33,9 +33,11 @@ import java.util.Date;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
@@ -55,6 +57,7 @@ import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockObtainFailedException;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.artifact.GavCalculator;
 import org.apache.maven.index.artifact.M2GavCalculator;
 import org.codehaus.plexus.util.StringUtils;
@@ -363,10 +366,9 @@ public class DefaultIndexingContext
     {
         Document hdr = new Document();
 
-        hdr.add( new Field( FLD_DESCRIPTOR, FLD_DESCRIPTOR_CONTENTS, Field.Store.YES, Field.Index.NOT_ANALYZED ) );
+        hdr.add( new Field( FLD_DESCRIPTOR, FLD_DESCRIPTOR_CONTENTS, IndexerField.KEYWORD_STORED ) );
 
-        hdr.add( new Field( FLD_IDXINFO, VERSION + ArtifactInfo.FS + getRepositoryId(), Field.Store.YES,
-                            Field.Index.NO ) );
+        hdr.add( new StoredField( FLD_IDXINFO, VERSION + ArtifactInfo.FS + getRepositoryId() ) );
 
         IndexWriter w = getIndexWriter();
 
@@ -876,10 +878,8 @@ public class DefaultIndexingContext
                                              String listField )
     {
         final Document groupDoc = new Document();
-        groupDoc.add( new Field( field, //
-            fieldValue, Field.Store.YES, Field.Index.NOT_ANALYZED ) );
-        groupDoc.add( new Field( listField, //
-            ArtifactInfo.lst2str( groups ), Field.Store.YES, Field.Index.NO ) );
+        groupDoc.add( new Field( field, fieldValue, IndexerField.KEYWORD_STORED ) );
+        groupDoc.add( new StoredField( listField, ArtifactInfo.lst2str( groups ) ) );
         return groupDoc;
     }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -43,7 +43,7 @@ import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
@@ -242,7 +242,11 @@ public class DefaultIndexingContext
             try
             {
                 // unlock the dir forcibly
-                if ( IndexWriter.isLocked( indexDirectory ) )
+                try
+                {
+                    indexDirectory.obtainLock( IndexWriter.WRITE_LOCK_NAME ).close();
+                }
+                catch ( LockObtainFailedException failed )
                 {
                     unlockForcibly( lockFactory, indexDirectory );
                 }
@@ -279,7 +283,11 @@ public class DefaultIndexingContext
             closeReaders();
 
             // unlock the dir forcibly
-            if ( IndexWriter.isLocked( indexDirectory ) )
+            try
+            {
+                indexDirectory.obtainLock( IndexWriter.WRITE_LOCK_NAME ).close();
+            }
+            catch ( LockObtainFailedException failed )
             {
                 unlockForcibly( lockFactory, indexDirectory );
             }
@@ -310,7 +318,7 @@ public class DefaultIndexingContext
         // check for descriptor if this is not a "virgin" index
         if ( getSize() > 0 )
         {
-            final TopScoreDocCollector collector = TopScoreDocCollector.create( 1 );
+            final TopScoreDocCollector collector = TopScoreDocCollector.create( 1, Integer.MAX_VALUE );
             final IndexSearcher indexSearcher = acquireIndexSearcher();
             try
             {
@@ -532,7 +540,7 @@ public class DefaultIndexingContext
 
         this.indexWriter = new NexusIndexWriter( getIndexDirectory(), getWriterConfig() );
         this.indexWriter.commit(); // LUCENE-2386
-        this.searcherManager = new SearcherManager( indexWriter, false, new NexusIndexSearcherFactory( this ) );
+        this.searcherManager = new SearcherManager( indexWriter, false, false, new NexusIndexSearcherFactory( this ) );
     }
 
     /**
@@ -675,7 +683,7 @@ public class DefaultIndexingContext
             {
                 int numDocs = directoryReader.maxDoc();
                 
-                Bits liveDocs = MultiFields.getLiveDocs( directoryReader );
+                Bits liveDocs = MultiBits.getLiveDocs( directoryReader );
                 for ( int i = 0; i < numDocs; i++ )
                 {
                     if ( liveDocs != null && !liveDocs.get( i ) )
@@ -692,7 +700,7 @@ public class DefaultIndexingContext
                     String uinfo = d.get( ArtifactInfo.UINFO );
                     if ( uinfo != null )
                     {
-                        collector = TopScoreDocCollector.create( 1 );
+                        collector = TopScoreDocCollector.create( 1, Integer.MAX_VALUE );
                         s.search( new TermQuery( new Term( ArtifactInfo.UINFO, uinfo ) ), collector );
                         if ( collector.getTotalHits() == 0 )
                         {
@@ -780,7 +788,7 @@ public class DefaultIndexingContext
             Set<String> allGroups = new LinkedHashSet<String>();
 
             int numDocs = r.maxDoc();
-            Bits liveDocs = MultiFields.getLiveDocs( r );
+            Bits liveDocs = MultiBits.getLiveDocs( r );
 
             for ( int i = 0; i < numDocs; i++ )
             {
@@ -841,14 +849,16 @@ public class DefaultIndexingContext
     protected Set<String> getGroups( String field, String filedValue, String listField )
         throws IOException, CorruptIndexException
     {
-        final TopScoreDocCollector collector = TopScoreDocCollector.create( 1 );
+        final TopScoreDocCollector collector = TopScoreDocCollector.create( 1, Integer.MAX_VALUE );
         final IndexSearcher indexSearcher = acquireIndexSearcher();
         try
         {
             indexSearcher.search( new TermQuery( new Term( field, filedValue ) ), collector );
             TopDocs topDocs = collector.topDocs();
-            Set<String> groups = new LinkedHashSet<String>( Math.max( 10, topDocs.totalHits ) );
-            if ( topDocs.totalHits > 0 )
+            // In Lucene 7 topDocs.totalHits is now a long, but we can safely cast this to an int because
+            // indexes are still bound to at most 2 billion (Integer.MAX_VALUE) documents
+            Set<String> groups = new LinkedHashSet<String>( (int) Math.max( 10L, topDocs.totalHits.value ) );
+            if ( topDocs.totalHits.value > 0 )
             {
                 Document doc = indexSearcher.doc( topDocs.scoreDocs[0].doc );
                 String groupList = doc.get( listField );

--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
@@ -44,8 +44,6 @@ public class IndexUtils
 {
     public static final String TIMESTAMP_FILE = "timestamp";
 
-    private static final int BUFFER_SIZE = 16384;
-
     // Directory
 
     public static void copyDirectory( Directory source, Directory target )

--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexUtils.java
@@ -29,6 +29,7 @@ import java.util.Date;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.store.Directory;
@@ -36,6 +37,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.IndexerField;
 import org.codehaus.plexus.util.FileUtils;
 
 public class IndexUtils
@@ -149,12 +151,12 @@ public class IndexUtils
         Document document = new Document();
 
         // unique key
-        document.add( new Field( ArtifactInfo.UINFO, ai.getUinfo(), Field.Store.YES, Field.Index.NOT_ANALYZED ) );
+        document.add( new Field( ArtifactInfo.UINFO, ai.getUinfo(), IndexerField.KEYWORD_STORED ) );
 
         if ( updateLastModified || doc.getField( ArtifactInfo.LAST_MODIFIED ) == null )
         {
-            document.add( new Field( ArtifactInfo.LAST_MODIFIED, //
-                Long.toString( System.currentTimeMillis() ), Field.Store.YES, Field.Index.NO ) );
+            document.add( new StoredField( ArtifactInfo.LAST_MODIFIED, //
+                Long.toString( System.currentTimeMillis() ) ) );
         }
         else
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/context/NexusAnalyzer.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/NexusAnalyzer.java
@@ -21,6 +21,8 @@ package org.apache.maven.index.context;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.util.CharTokenizer;
 import org.apache.maven.index.creator.JarFileContentsIndexCreator;
 
@@ -40,7 +42,8 @@ public final class NexusAnalyzer
         @Override
         protected TokenStreamComponents createComponents( String fieldName )
         {
-            return new TokenStreamComponents( new DeprecatedClassnamesTokenizer() );
+            final Tokenizer tokenizer = new DeprecatedClassnamesTokenizer();
+            return new TokenStreamComponents( tokenizer, new LowerCaseFilter( tokenizer ) );
         }
     };
 
@@ -49,7 +52,8 @@ public final class NexusAnalyzer
         @Override
         protected TokenStreamComponents createComponents( String filedName )
         {
-            return new TokenStreamComponents( new LetterOrDigitTokenizer() );
+            final Tokenizer tokenizer = new LetterOrDigitTokenizer();
+            return new TokenStreamComponents( tokenizer, new LowerCaseFilter( tokenizer ) );
         }
     };
 
@@ -103,12 +107,6 @@ public final class NexusAnalyzer
         {
             return i != '\n';
         }
-        
-        @Override
-        protected int normalize( int c )
-        {
-            return Character.toLowerCase( c );
-        }
     }
 
     public static class LetterOrDigitTokenizer
@@ -124,12 +122,5 @@ public final class NexusAnalyzer
         {
             return Character.isLetterOrDigit( c );
         }
-
-        @Override
-        protected int normalize( int c )
-        {
-            return Character.toLowerCase( c );
-        }
     }
-
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/NexusIndexWriter.java
@@ -63,7 +63,6 @@ public class NexusIndexWriter
         // default open mode is CreateOrAppend which suits us
         config.setRAMBufferSizeMB( 2.0 ); // old default
         config.setMergeScheduler( new SerialMergeScheduler() ); // merging serially
-        config.setWriteLockTimeout( IndexWriterConfig.WRITE_LOCK_TIMEOUT );
         return config;
     }
 }

--- a/indexer-core/src/main/java/org/apache/maven/index/context/NexusLegacyAnalyzer.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/NexusLegacyAnalyzer.java
@@ -21,6 +21,8 @@ package org.apache.maven.index.context;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.AnalyzerWrapper;
+import org.apache.lucene.analysis.LowerCaseFilter;
+import org.apache.lucene.analysis.Tokenizer;
 import org.apache.lucene.analysis.util.CharTokenizer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.maven.index.ArtifactInfo;
@@ -42,20 +44,16 @@ public final class NexusLegacyAnalyzer
         @Override
         protected TokenStreamComponents createComponents( final String fieldName )
         {
-            return new TokenStreamComponents( new CharTokenizer()
+            final Tokenizer tokenizer = new CharTokenizer()
             {
                 @Override
                 protected boolean isTokenChar( int c )
                 {
                     return Character.isLetterOrDigit( c );
                 }
+            };
 
-                @Override
-                protected int normalize( int c )
-                {
-                    return Character.toLowerCase( c );
-                }
-            } );
+            return new TokenStreamComponents( tokenizer, new LowerCaseFilter( tokenizer ) );
         }
     };
 

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/JarFileContentsIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/JarFileContentsIndexCreator.java
@@ -28,8 +28,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -52,7 +50,7 @@ public class JarFileContentsIndexCreator
     public static final String ID = "jarContent";
 
     public static final IndexerField FLD_CLASSNAMES = new IndexerField( MAVEN.CLASSNAMES, IndexerFieldVersion.V3,
-        "classnames", "Artifact Classes (tokenized)", Store.NO, Index.ANALYZED );
+        "classnames", "Artifact Classes (tokenized)", IndexerField.ANALYZED_NOT_STORED );
 
     /**
      * NexusAnalyzer makes exception with this field only, to keep backward compatibility with old consumers of
@@ -60,7 +58,7 @@ public class JarFileContentsIndexCreator
      * registered BEFORE FLD_CLASSNAMES_KW!
      */
     public static final IndexerField FLD_CLASSNAMES_KW = new IndexerField( MAVEN.CLASSNAMES, IndexerFieldVersion.V1,
-        "c", "Artifact Classes (tokenized on newlines only)", Store.YES, Index.ANALYZED );
+        "c", "Artifact Classes (tokenized on newlines only)", IndexerField.ANALYZED_STORED );
 
     public JarFileContentsIndexCreator()
     {

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
@@ -31,8 +31,6 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -61,10 +59,10 @@ public class MavenPluginArtifactInfoIndexCreator
     private static final String MAVEN_PLUGIN_PACKAGING = "maven-plugin";
 
     public static final IndexerField FLD_PLUGIN_PREFIX = new IndexerField( MAVEN.PLUGIN_PREFIX, IndexerFieldVersion.V1,
-        "px", "MavenPlugin prefix (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "px", "MavenPlugin prefix (as keyword, stored)", IndexerField.KEYWORD_STORED );
 
     public static final IndexerField FLD_PLUGIN_GOALS = new IndexerField( MAVEN.PLUGIN_GOALS, IndexerFieldVersion.V1,
-        "gx", "MavenPlugin goals (as keyword, stored)", Store.YES, Index.ANALYZED );
+        "gx", "MavenPlugin goals (as keyword, stored)", IndexerField.ANALYZED_STORED );
 
     public MavenPluginArtifactInfoIndexCreator()
     {

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/MinimalArtifactInfoIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/MinimalArtifactInfoIndexCreator.java
@@ -28,8 +28,7 @@ import java.util.Collection;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.Field.Index;
-import org.apache.lucene.document.Field.Store;
+import org.apache.lucene.document.StoredField;
 import org.apache.maven.index.ArtifactAvailability;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
@@ -67,46 +66,46 @@ public class MinimalArtifactInfoIndexCreator
      * Info: packaging, lastModified, size, sourcesExists, javadocExists, signatureExists. Stored, not indexed.
      */
     public static final IndexerField FLD_INFO = new IndexerField( NEXUS.INFO, IndexerFieldVersion.V1, "i",
-        "Artifact INFO (not indexed, stored)", Store.YES, Index.NO );
+        "Artifact INFO (not indexed, stored)", StoredField.TYPE );
 
     public static final IndexerField FLD_GROUP_ID_KW = new IndexerField( MAVEN.GROUP_ID, IndexerFieldVersion.V1, "g",
-        "Artifact GroupID (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact GroupID (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_GROUP_ID = new IndexerField( MAVEN.GROUP_ID, IndexerFieldVersion.V3,
-        "groupId", "Artifact GroupID (tokenized)", Store.NO, Index.ANALYZED );
+        "groupId", "Artifact GroupID (tokenized)", IndexerField.ANALYZED_NOT_STORED );
 
     public static final IndexerField FLD_ARTIFACT_ID_KW = new IndexerField( MAVEN.ARTIFACT_ID, IndexerFieldVersion.V1,
-        "a", "Artifact ArtifactID (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "a", "Artifact ArtifactID (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_ARTIFACT_ID = new IndexerField( MAVEN.ARTIFACT_ID, IndexerFieldVersion.V3,
-        "artifactId", "Artifact ArtifactID (tokenized)", Store.NO, Index.ANALYZED );
+        "artifactId", "Artifact ArtifactID (tokenized)", IndexerField.ANALYZED_NOT_STORED );
 
     public static final IndexerField FLD_VERSION_KW = new IndexerField( MAVEN.VERSION, IndexerFieldVersion.V1, "v",
-        "Artifact Version (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact Version (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_VERSION = new IndexerField( MAVEN.VERSION, IndexerFieldVersion.V3, "version",
-        "Artifact Version (tokenized)", Store.NO, Index.ANALYZED );
+        "Artifact Version (tokenized)", IndexerField.ANALYZED_NOT_STORED );
 
     public static final IndexerField FLD_PACKAGING = new IndexerField( MAVEN.PACKAGING, IndexerFieldVersion.V1, "p",
-        "Artifact Packaging (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact Packaging (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_EXTENSION = new IndexerField( MAVEN.EXTENSION, IndexerFieldVersion.V1, "e",
-        "Artifact extension (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact extension (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_CLASSIFIER = new IndexerField( MAVEN.CLASSIFIER, IndexerFieldVersion.V1, "l",
-        "Artifact classifier (as keyword)", Store.NO, Index.NOT_ANALYZED );
+        "Artifact classifier (as keyword)", IndexerField.KEYWORD_NOT_STORED );
 
     public static final IndexerField FLD_NAME = new IndexerField( MAVEN.NAME, IndexerFieldVersion.V1, "n",
-        "Artifact name (tokenized, stored)", Store.YES, Index.ANALYZED );
+        "Artifact name (tokenized, stored)", IndexerField.ANALYZED_STORED );
 
     public static final IndexerField FLD_DESCRIPTION = new IndexerField( MAVEN.DESCRIPTION, IndexerFieldVersion.V1,
-        "d", "Artifact description (tokenized, stored)", Store.YES, Index.ANALYZED );
+        "d", "Artifact description (tokenized, stored)", IndexerField.ANALYZED_STORED );
 
     public static final IndexerField FLD_LAST_MODIFIED = new IndexerField( MAVEN.LAST_MODIFIED, IndexerFieldVersion.V1,
-        "m", "Artifact last modified (not indexed, stored)", Store.YES, Index.NO );
+        "m", "Artifact last modified (not indexed, stored)", StoredField.TYPE );
 
     public static final IndexerField FLD_SHA1 = new IndexerField( MAVEN.SHA1, IndexerFieldVersion.V1, "1",
-        "Artifact SHA1 checksum (as keyword, stored)", Store.YES, Index.NOT_ANALYZED );
+        "Artifact SHA1 checksum (as keyword, stored)", IndexerField.KEYWORD_STORED );
 
     private Locator jl = new JavadocLocator();
 
@@ -310,18 +309,16 @@ public class MinimalArtifactInfoIndexCreator
         // legacy!
         if ( ai.getPrefix() != null )
         {
-            doc.add( new Field( ArtifactInfo.PLUGIN_PREFIX, ai.getPrefix(), Field.Store.YES,
-                                Field.Index.NOT_ANALYZED ) );
+            doc.add( new Field( ArtifactInfo.PLUGIN_PREFIX, ai.getPrefix(), IndexerField.KEYWORD_STORED ) );
         }
 
         if ( ai.getGoals() != null )
         {
-            doc.add( new Field( ArtifactInfo.PLUGIN_GOALS, ArtifactInfo.lst2str( ai.getGoals() ), Field.Store.YES,
-                Field.Index.NO ) );
+            doc.add( new StoredField( ArtifactInfo.PLUGIN_GOALS, ArtifactInfo.lst2str( ai.getGoals() ) ) );
         }
 
         doc.removeField( ArtifactInfo.GROUP_ID );
-        doc.add( new Field( ArtifactInfo.GROUP_ID, ai.getGroupId(), Field.Store.NO, Field.Index.NOT_ANALYZED ) );
+        doc.add( new Field( ArtifactInfo.GROUP_ID, ai.getGroupId(), IndexerField.KEYWORD_NOT_STORED ) );
     }
 
     public boolean updateArtifactInfo( Document doc, ArtifactInfo ai )

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/OsgiArtifactIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/OsgiArtifactIndexCreator.java
@@ -23,7 +23,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field;
 import org.apache.maven.index.ArtifactContext;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -72,95 +71,95 @@ public class OsgiArtifactIndexCreator
 
     public static final IndexerField FLD_SHA256 =
         new IndexerField( OSGI.SHA256, IndexerFieldVersion.V4, "sha256", "SHA-256 (not analyzed, stored)",
-                          Field.Store.YES, Field.Index.NOT_ANALYZED );
+                          IndexerField.KEYWORD_STORED );
 
     private static final String BSN = "Bundle-SymbolicName";
 
     public static final IndexerField FLD_BUNDLE_SYMBOLIC_NAME =
         new IndexerField( OSGI.SYMBOLIC_NAME, IndexerFieldVersion.V4, BSN, "Bundle-SymbolicName (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BV = "Bundle-Version";
 
     public static final IndexerField FLD_BUNDLE_VERSION =
-        new IndexerField( OSGI.VERSION, IndexerFieldVersion.V4, BV, "Bundle-Version (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.VERSION, IndexerFieldVersion.V4, BV, "Bundle-Version (indexed, stored)",
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BEP = "Export-Package";
 
     public static final IndexerField FLD_BUNDLE_EXPORT_PACKAGE =
         new IndexerField( OSGI.EXPORT_PACKAGE, IndexerFieldVersion.V4, BEP, "Export-Package (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     @Deprecated
     private static final String BES = "Export-Service";
     @Deprecated
     public static final IndexerField FLD_BUNDLE_EXPORT_SERVIVE =
         new IndexerField( OSGI.EXPORT_SERVICE, IndexerFieldVersion.V4, BES, "Export-Service (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BD = "Bundle-Description";
 
     public static final IndexerField FLD_BUNDLE_DESCRIPTION =
         new IndexerField( OSGI.DESCRIPTION, IndexerFieldVersion.V4, BD, "Bundle-Description (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BN = "Bundle-Name";
 
     public static final IndexerField FLD_BUNDLE_NAME =
-        new IndexerField( OSGI.NAME, IndexerFieldVersion.V4, BN, "Bundle-Name (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.NAME, IndexerFieldVersion.V4, BN, "Bundle-Name (indexed, stored)",
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BL = "Bundle-License";
 
     public static final IndexerField FLD_BUNDLE_LICENSE =
-        new IndexerField( OSGI.LICENSE, IndexerFieldVersion.V4, BL, "Bundle-License (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.LICENSE, IndexerFieldVersion.V4, BL, "Bundle-License (indexed, stored)",
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BDU = "Bundle-DocURL";
 
     public static final IndexerField FLD_BUNDLE_DOCURL =
-        new IndexerField( OSGI.DOCURL, IndexerFieldVersion.V4, BDU, "Bundle-DocURL (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+        new IndexerField( OSGI.DOCURL, IndexerFieldVersion.V4, BDU, "Bundle-DocURL (indexed, stored)",
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BIP = "Import-Package";
 
     public static final IndexerField FLD_BUNDLE_IMPORT_PACKAGE =
         new IndexerField( OSGI.IMPORT_PACKAGE, IndexerFieldVersion.V4, BIP, "Import-Package (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
 
     private static final String BRB = "Require-Bundle";
 
     public static final IndexerField FLD_BUNDLE_REQUIRE_BUNDLE =
         new IndexerField( OSGI.REQUIRE_BUNDLE, IndexerFieldVersion.V4, BRB, "Require-Bundle (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     private static final String PROVIDE_CAPABILITY = "Provide-Capability";
 
     public static final IndexerField FLD_BUNDLE_PROVIDE_CAPABILITY =
         new IndexerField( OSGI.PROVIDE_CAPABILITY, IndexerFieldVersion.V4, PROVIDE_CAPABILITY,
-                          "Provide-Capability (indexed, stored)", Field.Store.YES, Field.Index.ANALYZED );
+                          "Provide-Capability (indexed, stored)", IndexerField.ANALYZED_STORED );
 
     private static final String REQUIRE_CAPABILITY = "Require-Capability";
 
     public static final IndexerField FLD_BUNDLE_REQUIRE_CAPABILITY =
         new IndexerField( OSGI.REQUIRE_CAPABILITY, IndexerFieldVersion.V4, REQUIRE_CAPABILITY,
-                          "Require-Capability (indexed, stored)", Field.Store.YES, Field.Index.ANALYZED );
+                          "Require-Capability (indexed, stored)", IndexerField.ANALYZED_STORED );
 
     private static final String FRAGMENT_HOST = "Fragment-Host";
 
     public static final IndexerField FLD_BUNDLE_FRAGMENT_HOST =
         new IndexerField( OSGI.FRAGMENT_HOST, IndexerFieldVersion.V4, FRAGMENT_HOST, "Fragment-Host (indexed, stored)",
-                          Field.Store.YES, Field.Index.ANALYZED );
+                          IndexerField.ANALYZED_STORED );
 
     private static final String BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT = "Bundle-RequiredExecutionEnvironment";
 
     public static final IndexerField FLD_BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT =
         new IndexerField( OSGI.BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT, IndexerFieldVersion.V4,
                           BUNDLE_REQUIRED_EXECUTION_ENVIRONMENT,
-                          "Bundle-RequiredExecutionEnvironment (indexed, stored)", Field.Store.YES,
-                          Field.Index.ANALYZED );
+                          "Bundle-RequiredExecutionEnvironment (indexed, stored)",
+                          IndexerField.ANALYZED_STORED );
 
 
     public Collection<IndexerField> getIndexerFields()

--- a/indexer-core/src/main/java/org/apache/maven/index/incremental/DefaultIncrementalHandler.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/incremental/DefaultIncrementalHandler.java
@@ -40,7 +40,7 @@ import javax.inject.Singleton;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.context.IndexingContext;
@@ -158,7 +158,7 @@ public class DefaultIncrementalHandler
     {
         final List<Integer> chunk = new ArrayList<>();
         final IndexReader r = request.getIndexReader();
-        Bits liveDocs = MultiFields.getLiveDocs( r );
+        Bits liveDocs = MultiBits.getLiveDocs( r );
         for ( int i = 0; i < r.maxDoc(); i++ )
         {
             if ( liveDocs == null || liveDocs.get( i ) )

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -48,7 +48,8 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.context.DocumentFilter;
@@ -256,9 +257,9 @@ public class DefaultIndexUpdater
         try
         {
             r = DirectoryReader.open( directory );
-            w = new NexusIndexWriter( directory, new NexusAnalyzer(), false );
-            
-            Bits liveDocs = MultiFields.getLiveDocs( r );
+            w = new NexusIndexWriter( directory, new IndexWriterConfig( new NexusAnalyzer() ) );
+
+            Bits liveDocs = MultiBits.getLiveDocs( r );
 
             int numDocs = r.maxDoc();
 
@@ -273,7 +274,7 @@ public class DefaultIndexUpdater
 
                 if ( !filter.accept( d ) )
                 {
-                    boolean success = w.tryDeleteDocument( r, i );
+                    boolean success = w.tryDeleteDocument( r, i ) != -1;
                     // FIXME handle deletion failure
                 }
             }
@@ -289,7 +290,7 @@ public class DefaultIndexUpdater
         try
         {
             // analyzer is unimportant, since we are not adding/searching to/on index, only reading/deleting
-            w = new NexusIndexWriter( directory, new NexusAnalyzer(), false );
+            w = new NexusIndexWriter( directory, new IndexWriterConfig( new NexusAnalyzer() ) );
 
             w.commit();
         }
@@ -379,7 +380,7 @@ public class DefaultIndexUpdater
                                                        final IndexingContext context )
         throws IOException
     {
-        NexusIndexWriter w = new NexusIndexWriter( d, new NexusAnalyzer(), true );
+        NexusIndexWriter w = new NexusIndexWriter( d, new IndexWriterConfig( new NexusAnalyzer() ) );
         try
         {
             IndexDataReader dr = new IndexDataReader( is );

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
@@ -35,7 +35,7 @@ import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -143,7 +143,7 @@ public class IndexDataWriter
         throws IOException
     {
         int n = 0;
-        Bits liveDocs = MultiFields.getLiveDocs( r );
+        Bits liveDocs = MultiBits.getLiveDocs( r );
 
         if ( docIndexes == null )
         {

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
@@ -31,14 +31,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 import org.apache.lucene.document.Document;
-import org.apache.lucene.document.Field.Store;
-import org.apache.lucene.document.StringField;
+import org.apache.lucene.document.Field;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiFields;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
+import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.context.DefaultIndexingContext;
 import org.apache.maven.index.context.IndexingContext;
 
@@ -122,18 +122,19 @@ public class IndexDataWriter
     {
         {
             List<IndexableField> allGroupsFields = new ArrayList<>( 2 );
-            allGroupsFields.add( new StringField( ArtifactInfo.ALL_GROUPS, ArtifactInfo.ALL_GROUPS_VALUE, Store.YES ) );
-            allGroupsFields.add( new StringField( ArtifactInfo.ALL_GROUPS_LIST, ArtifactInfo.lst2str( allGroups ),
-                                                  Store.YES ) );
+            allGroupsFields.add( new Field( ArtifactInfo.ALL_GROUPS, ArtifactInfo.ALL_GROUPS_VALUE,
+                                            IndexerField.KEYWORD_STORED ) );
+            allGroupsFields.add( new Field( ArtifactInfo.ALL_GROUPS_LIST, ArtifactInfo.lst2str( allGroups ),
+                                            IndexerField.KEYWORD_STORED ) );
             writeDocumentFields( allGroupsFields );
         }
 
         {
             List<IndexableField> rootGroupsFields = new ArrayList<>( 2 );
-            rootGroupsFields.add( new StringField( ArtifactInfo.ROOT_GROUPS, ArtifactInfo.ROOT_GROUPS_VALUE,
-                                                   Store.YES ) );
-            rootGroupsFields.add( new StringField( ArtifactInfo.ROOT_GROUPS_LIST, ArtifactInfo.lst2str( rootGroups ),
-                                                   Store.YES ) );
+            rootGroupsFields.add( new Field( ArtifactInfo.ROOT_GROUPS, ArtifactInfo.ROOT_GROUPS_VALUE,
+                                             IndexerField.KEYWORD_STORED ) );
+            rootGroupsFields.add( new Field( ArtifactInfo.ROOT_GROUPS_LIST, ArtifactInfo.lst2str( rootGroups ),
+                                             IndexerField.KEYWORD_STORED ) );
             writeDocumentFields( rootGroupsFields );
         }
     }

--- a/indexer-core/src/test/java/org/apache/maven/index/AbstractRepoNexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/AbstractRepoNexusIndexerTest.java
@@ -29,7 +29,7 @@ import java.util.Set;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.search.grouping.GAGrouping;
@@ -514,7 +514,7 @@ public abstract class AbstractRepoNexusIndexerTest
     {
         IndexReader reader = context.acquireIndexSearcher().getIndexReader();
 
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
         for ( int i = 0; i < reader.maxDoc(); i++ )
         {
             if (liveDocs == null || liveDocs.get(i) )

--- a/indexer-core/src/test/java/org/apache/maven/index/Nexus737NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/Nexus737NexusIndexerTest.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.util.Bits;
 
 /** http://issues.sonatype.org/browse/NEXUS-737 */
@@ -45,7 +45,7 @@ public class Nexus737NexusIndexerTest
         throws Exception
     {
         IndexReader reader = context.acquireIndexSearcher().getIndexReader();
-        Bits liveDocs = MultiFields.getLiveDocs(reader);
+        Bits liveDocs = MultiBits.getLiveDocs(reader);
 
         int foundCount = 0;
 

--- a/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
@@ -20,8 +20,6 @@ package org.apache.maven.index;
  */
 
 import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -82,7 +80,7 @@ public class NexusIndexerTest
         
         // scored search against field having tokenized IndexerField only (should be impossible).
         q = indexer.constructQuery( MAVEN.NAME, "Some artifact name from Pom", SearchType.SCORED );
-        assertThat(q.toString(), is("(+n:some +n:artifact +n:name +n:from +n:pom*) n:\"some artifact name from pom\""));
+        assertThat(q.toString(), is("(+n:some +n:artifact +n:name +n:from +n:Pom*) n:\"some artifact name from pom\""));
     }
     
     public void testQueryCreatorNG()
@@ -118,19 +116,19 @@ public class NexusIndexerTest
         // scored search against field having untokenized indexerField only
         q = indexer.constructQuery( MAVEN.PACKAGING, "maven-archetype", SearchType.SCORED );
 
-        assertEquals( "p:maven-archetype p:maven-archetype*^0.8", q.toString() );
+        assertEquals( "p:maven-archetype (p:maven-archetype*)^0.8", q.toString() );
 
         // scored search against field having untokenized indexerField only
         q = indexer.constructQuery( MAVEN.ARTIFACT_ID, "commons-logging", SearchType.SCORED );
 
         assertEquals(
-            "(a:commons-logging a:commons-logging*^0.8) ((+artifactId:commons +artifactId:logging*) artifactId:\"commons logging\")",
+            "(a:commons-logging (a:commons-logging*)^0.8) ((+artifactId:commons +artifactId:logging*) artifactId:\"commons logging\")",
             q.toString() );
 
         // scored search against field having tokenized IndexerField only (should be impossible).
         q = indexer.constructQuery( MAVEN.NAME, "Some artifact name from Pom", SearchType.SCORED );
 
-        assertEquals( "(+n:some +n:artifact +n:name +n:from +n:pom*) n:\"some artifact name from pom\"", q.toString() );
+        assertEquals( "(+n:some +n:artifact +n:name +n:from +n:Pom*) n:\"some artifact name from pom\"", q.toString() );
 
         // keyword search against field having tokenized IndexerField only (should be impossible).
         q = indexer.constructQuery( MAVEN.NAME, "some artifact name from Pom", SearchType.EXACT );
@@ -444,7 +442,6 @@ public class NexusIndexerTest
 
         {
             BooleanQuery bq = new BooleanQuery.Builder()
-                .setDisableCoord( true )
                 .add( new WildcardQuery( new Term( ArtifactInfo.GROUP_ID, "testng*" ) ), Occur.SHOULD )
                 .add( new WildcardQuery( new Term( ArtifactInfo.ARTIFACT_ID, "testng*" ) ), Occur.SHOULD )
                 .setMinimumNumberShouldMatch( 1 )

--- a/indexer-core/src/test/java/org/apache/maven/index/context/NexusAnalyzerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/context/NexusAnalyzerTest.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.creator.MinimalArtifactInfoIndexCreator;
@@ -55,7 +55,7 @@ public class NexusAnalyzerTest
     protected void runAndCompare( IndexerField indexerField, String text, String[] expected )
         throws IOException
     {
-        Tokenizer ts = (Tokenizer) nexusAnalyzer.tokenStream(indexerField.getKey(), new StringReader( text ) );
+        TokenStream ts = nexusAnalyzer.tokenStream(indexerField.getKey(), new StringReader( text ) );
         ts.reset();
 
         ArrayList<String> tokenList = new ArrayList<String>();

--- a/indexer-core/src/test/resources/testQueryCreatorNGSearch/case01.txt
+++ b/indexer-core/src/test/resources/testQueryCreatorNGSearch/case01.txt
@@ -1,4 +1,4 @@
-### Searched for field urn:maven#groupId (with 2 registered index fields) using query "commons-logg" (QC create LQL "(g:commons-logg g:commons-logg*^0.8) ((+groupId:commons +groupId:logg*) groupId:"commons logg")")
+### Searched for field urn:maven#groupId (with 2 registered index fields) using query "commons-logg" (QC create LQL "(g:commons-logg (g:commons-logg*)^0.8) ((+groupId:commons +groupId:logg*) groupId:"commons logg")")
 test :: commons-logging:commons-logging:1.1:null:jar
 test :: commons-logging:commons-logging:1.1:sources:jar
 test :: commons-logging:commons-logging:1.0.4:null:jar

--- a/indexer-core/src/test/resources/testQueryCreatorNGSearch/case05.txt
+++ b/indexer-core/src/test/resources/testQueryCreatorNGSearch/case05.txt
@@ -1,4 +1,4 @@
-### Searched for field urn:maven#version (with 2 registered index fields) using query "1.0" (QC create LQL "(v:1.0 v:1.0*^0.8) ((+version:1 +version:0*) version:"1 0")")
+### Searched for field urn:maven#version (with 2 registered index fields) using query "1.0" (QC create LQL "(v:1.0 (v:1.0*)^0.8) ((+version:1 +version:0*) version:"1 0")")
 test :: proptest:proptest-archetype:1.0:null:maven-archetype
 test :: org.apache.maven.plugins:maven-core-it-plugin:1.0:null:maven-plugin
 test :: org.apache.maven.plugins:maven-core-it-plugin:1.0:sources:jar

--- a/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/indexer/examples/BasicUsageExample.java
+++ b/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/indexer/examples/BasicUsageExample.java
@@ -21,7 +21,7 @@ package org.apache.maven.indexer.examples;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
-import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.MultiBits;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
@@ -202,7 +202,7 @@ public class BasicUsageExample
             try
             {
                 final IndexReader ir = searcher.getIndexReader();
-                Bits liveDocs = MultiFields.getLiveDocs( ir );
+                Bits liveDocs = MultiBits.getLiveDocs( ir );
                 for ( int i = 0; i < ir.maxDoc(); i++ )
                 {
                     if ( liveDocs == null || liveDocs.get( i ) )

--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,13 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <failsafe.redirectTestOutputToFile>true</failsafe.redirectTestOutputToFile>
     <checkstyle.violation.ignore>MagicNumber,ParameterNumber,MethodLength,JavadocType,AvoidNestedBlocks,InterfaceIsType</checkstyle.violation.ignore>
 
     <eclipse-sisu.version>0.3.3</eclipse-sisu.version>
-    <lucene.version>5.5.5</lucene.version>
+    <lucene.version>8.1.1</lucene.version>
     <maven.version>3.5.2</maven.version>
     <resolver.version>1.1.0</resolver.version>
     <truezip.version>7.7.10</truezip.version>


### PR DESCRIPTION
Refactor to avoid using the following deprecated symbols:
 * Field.Index
 * Field.TermVector
 * Token

These symbols only exist to support transitioning from pre-4.0
Lucene APIs, so this will make it easier to move to newer Lucenes
in the future.

Signed-off-by: Mat Booth <mat.booth@redhat.com>