### PR TITLE
Change indexer-reader's Utils to call read() once

### DIFF
--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/Utils.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/Utils.java
@@ -97,7 +97,7 @@ public final class Utils
         {
             return null;
         }
-        return loadProperties( resource.read() );
+        return loadProperties( inputStream );
     }
 
     /**


### PR DESCRIPTION
This fixes a resource leak.