### PR TITLE
Fix race condition in FileResource

### DIFF
--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/DirectoryResourceHandler.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/DirectoryResourceHandler.java
@@ -23,6 +23,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -69,10 +70,11 @@ public class DirectoryResourceHandler
     }
 
     public InputStream read() throws IOException {
-      if (file.isFile()) {
+      try {
         return new BufferedInputStream(new FileInputStream(file));
+      } catch (FileNotFoundException e) {
+        return null;
       }
-      return null;
     }
 
     public OutputStream write() throws IOException {


### PR DESCRIPTION
There is a race between when isFile() is called and when new FileInputStream() is called.