### PR TITLE
Remove extra methods on things that aren't closable

### DIFF
--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/CachingResourceHandler.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/CachingResourceHandler.java
@@ -40,12 +40,6 @@ public class CachingResourceHandler
         {
             return null;
         }
-
-        public void close()
-            throws IOException
-        {
-            // nop
-        }
     };
 
     private final WritableResourceHandler local;
@@ -129,12 +123,6 @@ public class CachingResourceHandler
             {
                 localResource.close();
             }
-        }
-
-        public void close()
-            throws IOException
-        {
-            // nop
         }
     }
 

--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/HttpResourceHandler.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/HttpResourceHandler.java
@@ -63,10 +63,6 @@ public class HttpResourceHandler
       conn.setRequestProperty("User-Agent", "ASF Maven-Indexer-Reader/1.0");
       return new BufferedInputStream(conn.getInputStream());
     }
-
-    public void close() throws IOException {
-      // nop
-    }
   }
 
   public void close() throws IOException {


### PR DESCRIPTION
There are extra close methods on things that aren't Closeable. They don't override anything.