### PR TITLE
Add stream methods to Readers

### DIFF
--- a/indexer-reader/pom.xml
+++ b/indexer-reader/pom.xml
@@ -36,6 +36,10 @@ under the License.
     maven-indexer-core and its transitive dependencies.
   </description>
 
+  <properties>
+    <javaVersion>8</javaVersion>
+  </properties>
+
   <dependencies>
     <!-- Test -->
     <dependency>

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/ChunkReader.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/ChunkReader.java
@@ -26,11 +26,14 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UTFDataFormatException;
+import java.io.UncheckedIOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -95,6 +98,21 @@ public class ChunkReader
         {
             throw new RuntimeException( "error", e );
         }
+    }
+
+    public Stream<Map<String, String>> stream()
+    {
+        return StreamSupport.stream(spliterator(), false).onClose(() ->
+        {
+            try
+            {
+                close();
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 
     /**

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexReader.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexReader.java
@@ -23,6 +23,7 @@ import org.apache.maven.index.reader.ResourceHandler.Resource;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,6 +32,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.apache.maven.index.reader.Utils.loadProperties;
 import static org.apache.maven.index.reader.Utils.storeProperties;
@@ -184,6 +187,21 @@ public class IndexReader
     public Iterator<ChunkReader> iterator()
     {
         return new ChunkReaderIterator( remote, chunkNames.iterator() );
+    }
+
+    public Stream<ChunkReader> stream()
+    {
+        return StreamSupport.stream(spliterator(), false).onClose(() ->
+        {
+            try
+            {
+                close();
+            }
+            catch (IOException e)
+            {
+                throw new UncheckedIOException(e);
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
It would be nice if these things had stream() methods so that the detail about their closing can be attended to. The ChunkReader one doesn't really matter since it gets closed when the next ChunkReader is made. Also this doesn't automatically close anything unless you pass it through a flatMap() operation. Given these caveats I'm not sure if this is a good addition. What do you all think?
Maybe we could also make the streams returned able to handle parallelism?