### PR TITLE
Replace null checks with Objects.requireNonNull

### DIFF
--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexReader.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexReader.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 
 import static org.apache.maven.index.reader.Utils.loadProperties;
@@ -62,10 +63,7 @@ public class IndexReader
     public IndexReader( final WritableResourceHandler local, final ResourceHandler remote )
         throws IOException
     {
-        if ( remote == null )
-        {
-            throw new NullPointerException( "remote resource handler null" );
-        }
+        Objects.requireNonNull(remote, "remote resource handler null");
         this.local = local;
         this.remote = remote;
         remoteIndexProperties = loadProperties( remote.locate( Utils.INDEX_FILE_PREFIX + ".properties" ) );

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexWriter.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/IndexWriter.java
@@ -27,6 +27,7 @@ import java.text.ParseException;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -59,14 +60,8 @@ public class IndexWriter
     public IndexWriter( final WritableResourceHandler local, final String indexId, final boolean incrementalSupported )
         throws IOException
     {
-        if ( local == null )
-        {
-            throw new NullPointerException( "local resource handler null" );
-        }
-        if ( indexId == null )
-        {
-            throw new NullPointerException( "indexId null" );
-        }
+        Objects.requireNonNull(local, "local resource handler null");
+        Objects.requireNonNull(indexId, "indexId null");
         this.local = local;
         Properties indexProperties = loadProperties( local.locate( Utils.INDEX_FILE_PREFIX + ".properties" ) );
         if ( incrementalSupported && indexProperties != null )

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/Record.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/Record.java
@@ -20,6 +20,7 @@ package org.apache.maven.index.reader;
  */
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Maven 2 Index record.
@@ -41,14 +42,8 @@ public final class Record
 
         public EntryKey( final String name, final Class<T> proto )
         {
-            if ( name == null )
-            {
-                throw new NullPointerException( "name is null" );
-            }
-            if ( proto == null )
-            {
-                throw new NullPointerException( "proto is null" );
-            }
+            Objects.requireNonNull(name, "name is null");
+            Objects.requireNonNull(proto, "proto is null");
             this.name = name;
             this.proto = proto;
         }


### PR DESCRIPTION
Objects.requireNonNull was added in java 7. We can use that to check for nulls instead.