### PR TITLE
Add a default close method to the Resource interfaces that does nothing

### DIFF
--- a/indexer-reader/pom.xml
+++ b/indexer-reader/pom.xml
@@ -36,6 +36,10 @@ under the License.
     maven-indexer-core and its transitive dependencies.
   </description>
 
+  <properties>
+    <javaVersion>8</javaVersion>
+  </properties>
+
   <dependencies>
     <!-- Test -->
     <dependency>

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/ResourceHandler.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/ResourceHandler.java
@@ -53,4 +53,11 @@ public interface ResourceHandler
      */
     Resource locate( String name )
         throws IOException;
+
+    @Override
+    default void close()
+        throws IOException
+    {
+        // nop
+    }
 }

--- a/indexer-reader/src/main/java/org/apache/maven/index/reader/WritableResourceHandler.java
+++ b/indexer-reader/src/main/java/org/apache/maven/index/reader/WritableResourceHandler.java
@@ -50,6 +50,13 @@ public interface WritableResourceHandler
          */
         OutputStream write()
             throws IOException;
+
+        @Override
+        default void close()
+            throws IOException
+        {
+            // nop
+        }
     }
 
     /**

--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/DirectoryResourceHandler.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/DirectoryResourceHandler.java
@@ -56,10 +56,6 @@ public class DirectoryResourceHandler
     return new FileResource(new File(rootDirectory, name));
   }
 
-  public void close() throws IOException {
-    // nop
-  }
-
   private class FileResource
       implements WritableResource
   {
@@ -79,10 +75,6 @@ public class DirectoryResourceHandler
 
     public OutputStream write() throws IOException {
       return new BufferedOutputStream(new FileOutputStream(file));
-    }
-
-    public void close() throws IOException {
-      // nop
     }
   }
 

--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/HttpResourceHandler.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/HttpResourceHandler.java
@@ -64,8 +64,4 @@ public class HttpResourceHandler
       return new BufferedInputStream(conn.getInputStream());
     }
   }
-
-  public void close() throws IOException {
-    // nop
-  }
 }


### PR DESCRIPTION
I've not really seen a close() method I had to have on a WritableResource or a ResourceHandler. Think it would be a good idea to have add a default method that does nothing so we don't have to write noop methods everywhere? It seems like most of the important closing needs to happen with the streams the resources return.