### PR TITLE
Change http to https

### DIFF
--- a/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/indexer/examples/BasicUsageExample.java
+++ b/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/indexer/examples/BasicUsageExample.java
@@ -134,7 +134,7 @@ public class BasicUsageExample
         // Create context for central repository index
         centralContext =
             indexer.createIndexingContext( "central-context", "central", centralLocalCache, centralIndexDir,
-                                           "http://repo1.maven.org/maven2", null, true, true, indexers );
+                                           "https://repo1.maven.org/maven2", null, true, true, indexers );
 
         // Update the index (incremental update will happen if this is not 1st run and files are not deleted)
         // This whole block below should not be executed on every app start, but rather controlled by some configuration


### PR DESCRIPTION
Fixes:

```bash
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.maven.indexer.examples.BasicUsageExampleTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.914 s <<< FAILURE! - in org.apache.maven.indexer.examples.BasicUsageExampleTest
[ERROR] testApp(org.apache.maven.indexer.examples.BasicUsageExampleTest)  Time elapsed: 0.886 s  <<< ERROR!
java.io.IOException: Transfer for nexus-maven-repository-index.properties failed; Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties from http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties
        at org.apache.maven.indexer.examples.BasicUsageExampleTest.testApp(BasicUsageExampleTest.java:30)
Caused by: org.apache.maven.wagon.TransferFailedException: Error transferring file: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties from http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties
        at org.apache.maven.indexer.examples.BasicUsageExampleTest.testApp(BasicUsageExampleTest.java:30)
Caused by: java.io.IOException: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties
        at org.apache.maven.indexer.examples.BasicUsageExampleTest.testApp(BasicUsageExampleTest.java:30)
Caused by: java.io.IOException: Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/.index/nexus-maven-repository-index.properties
        at org.apache.maven.indexer.examples.BasicUsageExampleTest.testApp(BasicUsageExampleTest.java:30)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   BasicUsageExampleTest.testApp:30 » IO Transfer for nexus-maven-repository-inde...
[INFO]
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Maven :: Indexer Examples 6.1.0-SNAPSHOT:
[INFO]
[INFO] Maven :: Indexer Examples .......................... SUCCESS [  1.946 s]
[INFO] Maven :: Indexer Examples [Basic] .................. FAILURE [  4.365 s]
[INFO] Maven :: Indexer Examples [Spring] ................. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.473 s
[INFO] Finished at: 2020-03-21T14:32:36-06:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.22.2:test (default-test) on project indexer-examples-basic: There are test failures.
[ERROR]
[ERROR] Please refer to /home/mokha/development/maven-indexer/indexer-examples/indexer-examples-basic/target/surefire-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :indexer-examples-basic
```