### PR TITLE
(doc) Fix spurious javadoc @param tag

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/treeview/AbstractTreeNode.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/treeview/AbstractTreeNode.java
@@ -224,7 +224,7 @@ public abstract class AbstractTreeNode
     /**
      * Set the version of this node.
      * 
-     * @param String
+     * @param version
      */
     public void setVersion( String version )
     {


### PR DESCRIPTION
Missed that one in #73.