### PR TITLE
Remove guava dependency from indexer-core

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -40,11 +40,6 @@ under the License.
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-
     <!-- DI -->
     <dependency>
       <groupId>javax.inject</groupId>

--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfo.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactInfo.java
@@ -37,8 +37,6 @@ import org.eclipse.aether.version.InvalidVersionSpecificationException;
 import org.eclipse.aether.version.Version;
 import org.eclipse.aether.version.VersionScheme;
 
-import com.google.common.base.Strings;
-
 /**
  * ArtifactInfo holds the values known about an repository artifact. This is a simple Value Object kind of stuff.
  * Phasing out.
@@ -431,9 +429,10 @@ public class ArtifactInfo
     public String toString()
     {
         final StringBuilder result = new StringBuilder( getUinfo() );
-        if ( !Strings.isNullOrEmpty( getPackaging() ) )
+        String packaging = getPackaging();
+        if (packaging != null && !packaging.isEmpty())
         {
-            result.append( "[" ).append( getPackaging() ).append( "]" );
+            result.append( "[" ).append( packaging ).append( "]" );
         }
         return result.toString();
     }

--- a/indexer-core/src/main/java/org/apache/maven/index/context/TrackingLockFactory.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/TrackingLockFactory.java
@@ -1,5 +1,7 @@
 package org.apache.maven.index.context;
 
+import static java.util.Objects.requireNonNull;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,13 +23,13 @@ package org.apache.maven.index.context;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.Lock;
 import org.apache.lucene.store.LockFactory;
-import static com.google.common.base.Preconditions.checkNotNull;
-import java.util.HashSet;
 
 /**
  *
@@ -43,7 +45,7 @@ final class TrackingLockFactory
 
     TrackingLockFactory( final LockFactory delegate )
     {
-        this.delegate = checkNotNull( delegate );
+        this.delegate = requireNonNull( delegate );
         this.emittedLocks = Collections.newSetFromMap( new ConcurrentHashMap<TrackingLock, Boolean>() );
     }
 
@@ -78,8 +80,8 @@ final class TrackingLockFactory
 
         TrackingLock( final Lock delegate, final String name )
         {
-            this.delegate = checkNotNull( delegate );
-            this.name = checkNotNull( name );
+            this.delegate = requireNonNull( delegate );
+            this.name = requireNonNull( name );
         }
 
         String getName()

--- a/indexer-core/src/main/java/org/apache/maven/index/packer/IndexPackingRequest.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/packer/IndexPackingRequest.java
@@ -1,5 +1,7 @@
 package org.apache.maven.index.packer;
 
+import static java.util.Objects.requireNonNull;
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,8 +28,6 @@ import java.util.Collection;
 import org.apache.lucene.index.IndexReader;
 import org.apache.maven.index.context.IndexingContext;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 /**
  * An index packing request.
  */
@@ -53,11 +53,11 @@ public class IndexPackingRequest
 
     public IndexPackingRequest( final IndexingContext context, final IndexReader indexReader, final File targetDir )
     {
-        this.context = checkNotNull( context );
+        this.context = requireNonNull( context );
 
-        this.indexReader = checkNotNull( indexReader );
+        this.indexReader = requireNonNull( indexReader );
 
-        this.targetDir = checkNotNull( targetDir );
+        this.targetDir = requireNonNull( targetDir );
 
         this.createIncrementalChunks = true;
 

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -27,11 +27,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UTFDataFormatException;
 import java.util.Date;
-import java.util.zip.GZIPInputStream;
-
-import com.google.common.base.Strings;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.zip.GZIPInputStream;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
@@ -159,7 +158,7 @@ public class IndexDataReader
         // Fix up UINFO field wrt MINDEXER-41
         final Field uinfoField = (Field) doc.getField( ArtifactInfo.UINFO );
         final String info =  doc.get( ArtifactInfo.INFO );
-        if ( uinfoField != null && !Strings.isNullOrEmpty( info ) )
+        if ( uinfoField != null && info != null && !info.isEmpty() )
         {
             final String[] splitInfo = ArtifactInfo.FS_PATTERN.split( info );
             if ( splitInfo.length > 6 )


### PR DESCRIPTION
It suffers from multiple CVEs:
* guava < 24.1.1 is vulnerable to CVE-2018-10237.
* guava < 30.0 is vulnerable to CVE-2020-8908.

Moving to guava 30.1 will require moving to Java 8 so it's actually
simpler to just remove the dependency altogether.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>