### PR TITLE
MINDEXER-127: Maven repository indexing error: java.nio.channels.Over…

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -607,7 +607,6 @@ public class DefaultIndexingContext
     {
         closeReaders();
         deleteIndexFiles( true );
-        openAndWarmup();
         try
         {
             prepareIndex( true );


### PR DESCRIPTION
…lappingFileLockException

The fix prevents the openAndWarmup() method of DefaultIndexingContext to be invoked twice during purge() method call
in order to prevent an attempt to lock twice the same incex as this method is invoked from a subsequent prepareIndex()
 method call.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>