### PR TITLE
Update release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,6 +374,11 @@ under the License.
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.2.4</version>
         </plugin>
+        <plugin><!-- TODO remove when upgrading parnet POM to 35 -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>3.0.0-M5</version>
+        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>


### PR DESCRIPTION
As it causes havoc while releasing 6.1.0
but parent is not yet released, so put
yet-another TODO into POM.