### PR TITLE
[MINDEXER-140] Fix double invocation of DefaultIndexingContext.setIndexDirectoryFile

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -125,7 +125,8 @@ public class DefaultIndexingContext
                                     String repositoryUrl, String indexUpdateUrl,
                                     List<? extends IndexCreator> indexCreators, Directory indexDirectory,
                                     TrackingLockFactory lockFactory,
-                                    boolean reclaimIndex )
+                                    boolean reclaimIndex,
+                                    File indexDirectoryFile )
         throws ExistingLuceneIndexMismatchException, IOException
     {
 
@@ -164,7 +165,7 @@ public class DefaultIndexingContext
 
         prepareIndex( reclaimIndex );
 
-        setIndexDirectoryFile( null );
+        setIndexDirectoryFile( indexDirectoryFile );
     }
 
     private DefaultIndexingContext( String id, String repositoryId, File repository, File indexDirectoryFile,
@@ -173,9 +174,8 @@ public class DefaultIndexingContext
         throws IOException, ExistingLuceneIndexMismatchException
     {
         this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators,
-            FSDirectory.open( indexDirectoryFile.toPath(), lockFactory ), lockFactory, reclaimIndex );
-
-        setIndexDirectoryFile( indexDirectoryFile );
+            FSDirectory.open( indexDirectoryFile.toPath(), lockFactory ), lockFactory, reclaimIndex,
+                indexDirectoryFile );
     }
 
     public DefaultIndexingContext( String id, String repositoryId, File repository, File indexDirectoryFile,
@@ -194,12 +194,9 @@ public class DefaultIndexingContext
         throws IOException, ExistingLuceneIndexMismatchException
     {
         this( id, repositoryId, repository, repositoryUrl, indexUpdateUrl, indexCreators, indexDirectory, null,
-              reclaimIndex ); // Lock factory already installed - pass null
-
-        if ( indexDirectory instanceof FSDirectory )
-        {
-            setIndexDirectoryFile( ( (FSDirectory) indexDirectory ).getDirectory().toFile() );
-        }
+              reclaimIndex, indexDirectory instanceof FSDirectory
+                        ? ( (FSDirectory) indexDirectory ).getDirectory().toFile() : null
+        ); // Lock factory already installed - pass null
     }
 
     public Directory getIndexDirectory()

--- a/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/index/examples/indexing/RepositoryIndexerFactory.java
+++ b/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/index/examples/indexing/RepositoryIndexerFactory.java
@@ -65,7 +65,7 @@ public class RepositoryIndexerFactory
     private IndexingContext createIndexingContext( String repositoryId, File repositoryBasedir, File indexDir )
         throws IOException
     {
-        return getIndexer().createIndexingContext( repositoryId + "/ctx", repositoryId, repositoryBasedir, indexDir,
+        return getIndexer().createIndexingContext( repositoryId + "-ctx", repositoryId, repositoryBasedir, indexDir,
                                                    null, null, true,
                                                    // if context should be searched in non-targeted mode.
                                                    true, // if indexDirectory is known to contain (or should contain)


### PR DESCRIPTION
DefaultIndexingContext invokes method setIndexDirectoryFile two times (if indexDirectory set): once with null and once with given indexDirectory.

In first case, ID is used to create temp directory, just to have 2nd invocation use passed in directory (and leave temp directory created in 1st invocation alone).

This bug, in relation to commit 019edb7ff87a505372ad4f469c1b2a6c9d4ae292 broke Spring examples, as it seems Spring example contained a typo since beginning: it uses "/" (slash) in context ID.

Files.createTempDirectory fails if prefix contains path separator.

---

https://issues.apache.org/jira/browse/MINDEXER-140