### PR TITLE
[MINDEXER-139] Decouple from Plexus

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -47,11 +47,6 @@ under the License.
     </dependency>
 
     <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
       <scope>provided</scope>
@@ -60,11 +55,6 @@ under the License.
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.sisu</groupId>
-      <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -141,6 +131,12 @@ under the License.
     <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.sisu</groupId>
+      <artifactId>org.eclipse.sisu.plexus</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/creator/MavenPluginArtifactInfoIndexCreator.java
@@ -37,8 +37,7 @@ import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
 import org.apache.maven.index.IndexerFieldVersion;
 import org.apache.maven.index.MAVEN;
-import org.codehaus.plexus.configuration.PlexusConfiguration;
-import org.codehaus.plexus.configuration.xml.XmlPlexusConfiguration;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 
 /**
@@ -96,16 +95,16 @@ public class MavenPluginArtifactInfoIndexCreator
                 try ( InputStream is = new BufferedInputStream( zipFile.getInputStream( zipEntry ) ) )
                 {
                     // here the reader is closed
-                    PlexusConfiguration plexusConfig =
-                        new XmlPlexusConfiguration( Xpp3DomBuilder.build( new InputStreamReader( is ) ) );
+                    Xpp3Dom plexusConfig =
+                        Xpp3DomBuilder.build( new InputStreamReader( is ) );
 
                     ai.setPrefix( plexusConfig.getChild( "goalPrefix" ).getValue() );
 
                     ai.setGoals( new ArrayList<>() );
 
-                    PlexusConfiguration[] mojoConfigs = plexusConfig.getChild( "mojos" ).getChildren( "mojo" );
+                    Xpp3Dom[] mojoConfigs = plexusConfig.getChild( "mojos" ).getChildren( "mojo" );
 
-                    for ( PlexusConfiguration mojoConfig : mojoConfigs )
+                    for ( Xpp3Dom mojoConfig : mojoConfigs )
                     {
                         ai.getGoals().add( mojoConfig.getChild( "goal" ).getValue() );
                     }

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/WagonHelper.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/WagonHelper.java
@@ -19,6 +19,9 @@ package org.apache.maven.index.updater;
  * under the License.
  */
 
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.apache.maven.wagon.ConnectionException;
 import org.apache.maven.wagon.ResourceDoesNotExistException;
 import org.apache.maven.wagon.Wagon;
@@ -29,8 +32,6 @@ import org.apache.maven.wagon.authorization.AuthorizationException;
 import org.apache.maven.wagon.events.TransferListener;
 import org.apache.maven.wagon.proxy.ProxyInfo;
 import org.apache.maven.wagon.repository.Repository;
-import org.codehaus.plexus.PlexusContainer;
-import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,15 +51,14 @@ import java.nio.file.Files;
  */
 public class WagonHelper
 {
-    private final PlexusContainer plexusContainer;
+    private final Injector injector;
 
-    public WagonHelper( final PlexusContainer plexusContainer )
+    public WagonHelper( final Injector injector )
     {
-        this.plexusContainer = plexusContainer;
+        this.injector = injector;
     }
 
     public WagonFetcher getWagonResourceFetcher( final TransferListener listener )
-        throws ComponentLookupException
     {
         return getWagonResourceFetcher( listener, null, null );
     }
@@ -68,17 +68,15 @@ public class WagonHelper
      * @param authenticationInfo
      * @param proxyInfo
      * @return
-     * @throws ComponentLookupException
      * @deprecated use getWagonResourceFetcher with protocol argument
      */
     public WagonFetcher getWagonResourceFetcher( final TransferListener listener,
                                                  final AuthenticationInfo authenticationInfo,
                                                  final ProxyInfo proxyInfo )
-        throws ComponentLookupException
     {
         // we limit ourselves to HTTP only
-        return new WagonFetcher( plexusContainer.lookup( Wagon.class, "http" ), listener, authenticationInfo,
-                                 proxyInfo );
+        return new WagonFetcher( injector.getInstance( Key.get( Wagon.class, Names.named( "http" ) ) ),
+                listener, authenticationInfo, proxyInfo );
     }
 
     /**
@@ -87,16 +85,15 @@ public class WagonHelper
      * @param proxyInfo
      * @param protocol           protocol supported by wagon http/https
      * @return
-     * @throws ComponentLookupException
      * @since 4.1.3
      */
     public WagonFetcher getWagonResourceFetcher( final TransferListener listener,
-                                                 final AuthenticationInfo authenticationInfo, final ProxyInfo proxyInfo,
-                                                 String protocol )
-        throws ComponentLookupException
+                                                 final AuthenticationInfo authenticationInfo,
+                                                 final ProxyInfo proxyInfo,
+                                                 final String protocol )
     {
-        return new WagonFetcher( plexusContainer.lookup( Wagon.class, protocol ), listener, authenticationInfo,
-                                 proxyInfo );
+        return new WagonFetcher( injector.getInstance( Key.get( Wagon.class, Names.named( protocol ) ) ),
+                listener, authenticationInfo, proxyInfo );
     }
 
     public static class WagonFetcher

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterEmbeddingIT.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterEmbeddingIT.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.inject.Injector;
 import junit.framework.TestCase;
 
 import org.apache.maven.index.context.DefaultIndexingContext;
@@ -76,7 +77,7 @@ public class DefaultIndexUpdaterEmbeddingIT
 
         updater = container.lookup( IndexUpdater.class, "default" );
 
-        wagonHelper = new WagonHelper( container );
+        wagonHelper = new WagonHelper( container.lookup( Injector.class ) );
     }
 
     @Override

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
@@ -29,6 +29,7 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.TimeZone;
 
+import com.google.inject.Injector;
 import org.apache.maven.index.context.IndexingContext;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.jetty.server.Handler;
@@ -100,7 +101,7 @@ public class DownloadRemoteIndexerManagerTest
         overwriteIndex( index2, centralIndex );
 
         iur =
-            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer() ).getWagonResourceFetcher( null ) );
+            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer().lookup( Injector.class ) ).getWagonResourceFetcher( null ) );
         iur.setForceFullUpdate( true );
 
         updater.fetchAndUpdateIndex( iur );
@@ -111,7 +112,7 @@ public class DownloadRemoteIndexerManagerTest
         overwriteIndex( index1, centralIndex );
 
         iur =
-            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer() ).getWagonResourceFetcher( null ) );
+            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer().lookup( Injector.class ) ).getWagonResourceFetcher( null ) );
         iur.setForceFullUpdate( true );
         // just a dummy filter to invoke filtering! -- this is what I broke unnoticing it
         iur.setDocumentFilter( doc -> true );
@@ -124,7 +125,7 @@ public class DownloadRemoteIndexerManagerTest
         overwriteIndex( index2, centralIndex );
 
         iur =
-            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer() ).getWagonResourceFetcher( null ) );
+            new IndexUpdateRequest( centralContext, new WagonHelper( getContainer().lookup( Injector.class ) ).getWagonResourceFetcher( null ) );
         iur.setForceFullUpdate( true );
 
         updater.fetchAndUpdateIndex( iur );

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/FullBootProofOfConcept.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/FullBootProofOfConcept.java
@@ -26,6 +26,7 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.inject.Injector;
 import org.apache.maven.index.context.DefaultIndexingContext;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexingContext;
@@ -168,7 +169,7 @@ public class FullBootProofOfConcept
             }
         };
 
-        WagonHelper wh = new WagonHelper( container );
+        WagonHelper wh = new WagonHelper( container.lookup( Injector.class ) );
 
         WagonFetcher wf = wh.getWagonResourceFetcher( tl, null, null );
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,18 +154,6 @@ under the License.
       </dependency>
 
       <dependency>
-        <groupId>javax.annotation</groupId>
-        <artifactId>javax.annotation-api</artifactId>
-        <version>1.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>aopalliance</groupId>
-        <artifactId>aopalliance</artifactId>
-        <version>1.0</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guice.version}</version>


### PR DESCRIPTION
Plexus is not needed anymore for indexer, while
it retains all the functionalities. WagonHelper is
modified to use Injector instead.

Still, plexus is used in UTs/ITs, hence it is
present but only in test scope, as all the "injected
tests" are plexus based, hence redoing that is
much bigger effort.

---

https://issues.apache.org/jira/browse/MINDEXER-139