### PR TITLE
[MINDEXER-145] Update parent POM and dependencies

### DIFF
--- a/indexer-examples/indexer-examples-spring/pom.xml
+++ b/indexer-examples/indexer-examples-spring/pom.xml
@@ -35,7 +35,7 @@ under the License.
   </description>
 
   <properties>
-    <version.spring>5.3.15</version.spring>
+    <version.spring>5.3.16</version.spring>
   </properties>
 
   <build>

--- a/indexer-examples/indexer-examples-spring/pom.xml
+++ b/indexer-examples/indexer-examples-spring/pom.xml
@@ -35,7 +35,7 @@ under the License.
   </description>
 
   <properties>
-    <version.spring>5.3.16</version.spring>
+    <version.spring>5.3.19</version.spring>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <version>35</version>
+    <version>36</version>
     <relativePath />
   </parent>
 
@@ -92,11 +92,11 @@ under the License.
     <eclipse-sisu.version>0.3.5</eclipse-sisu.version>
     <guice.version>5.1.0</guice.version>
     <lucene.version>8.11.1</lucene.version>
-    <maven.version>3.8.4</maven.version>
-    <resolver.version>1.7.3</resolver.version>
+    <maven.version>3.8.5</maven.version>
+    <resolver.version>1.8.0</resolver.version>
     <archetype.version>3.2.1</archetype.version>
     <wagon.version>3.5.1</wagon.version>
-    <surefire.version>2.22.2</surefire.version>
+    <surefire.version>3.0.0-M6</surefire.version>
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>
     <maven.site.path>maven-indexer-archives/maven-indexer-LATEST</maven.site.path>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.maven</groupId>
     <artifactId>maven-parent</artifactId>
-    <!-- TODO: on update parent version, apply pluginMgmt TODOs as well -->
-    <version>34</version>
+    <version>35</version>
     <relativePath />
   </parent>
 
@@ -99,7 +98,7 @@ under the License.
     <wagon.version>3.5.1</wagon.version>
     <surefire.version>2.22.2</surefire.version>
     <slf4j.version>1.7.36</slf4j.version>
-    <logback.version>1.2.10</logback.version>
+    <logback.version>1.2.11</logback.version>
     <maven.site.path>maven-indexer-archives/maven-indexer-LATEST</maven.site.path>
     <project.build.outputTimestamp>2022-02-14T10:26:38Z</project.build.outputTimestamp>
   </properties>
@@ -143,7 +142,7 @@ under the License.
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1-jre</version>
+        <version>31.1-jre</version>
       </dependency>
 
       <!-- DI -->
@@ -359,16 +358,6 @@ under the License.
     </plugins>
     <pluginManagement>
       <plugins>
-        <plugin><!-- TODO remove when upgrading parent POM to 35 -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
-        </plugin>
-        <plugin><!-- TODO remove when upgrading parent POM to 35 -->
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.0-M5</version>
-        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>animal-sniffer-maven-plugin</artifactId>
@@ -382,7 +371,7 @@ under the License.
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.2.1</version>
+              <version>9.3</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Updates:
* parent POM to 36
* Maven to 3.8.5
* Resolver to 1.8.0
* logback to 1.2.11
* test/guava to 31
* examples/spring to 5.3.19

Build:
* surefire to 3.0.0-M6
* checkstyle (m-checkstyle-p dependency) to 9.3

---

Obsoletes https://github.com/apache/maven-indexer/pull/185
https://issues.apache.org/jira/browse/MINDEXER-145