### PR TITLE
[MINDEXER-144] IOOBEx on GAV local metadata

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultArtifactContextProducer.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultArtifactContextProducer.java
@@ -144,6 +144,7 @@ public class DefaultArtifactContextProducer
         String filename = file.getName();
 
         return !filename.equals( "maven-metadata.xml" )
+                && !( filename.startsWith( "maven-metadata-" ) && filename.endsWith( ".xml" ) )
                 // || filename.endsWith( "-javadoc.jar" )
                 // || filename.endsWith( "-javadocs.jar" )
                 // || filename.endsWith( "-sources.jar" )

--- a/indexer-core/src/main/java/org/apache/maven/index/artifact/M2GavCalculator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/artifact/M2GavCalculator.java
@@ -91,7 +91,8 @@ public class M2GavCalculator
                 s = s.substring( 0, s.length() - 4 );
             }
 
-            if ( s.endsWith( "maven-metadata.xml" ) )
+            if ( s.endsWith( "maven-metadata.xml" )
+                    || ( fileName.startsWith( "maven-metadata-" ) && fileName.contains( ".xml" ) ) )
             {
                 return null;
             }

--- a/indexer-core/src/test/java/org/apache/maven/index/artifact/M2GavCalculatorTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/artifact/M2GavCalculatorTest.java
@@ -565,6 +565,26 @@ public class M2GavCalculatorTest
 
         path = gavCalculator.gavToPath( gav );
         assertEquals( "/foo/artifact/SNAPSHOT/artifact-20080623.175436-1.jar", path );
+
+        gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/1.0-SNAPSHOT/hintmod-1.0-SNAPSHOT.pom" );
+        assertEquals( "dev.mbien", gav.getGroupId() );
+        assertEquals( "hintmod", gav.getArtifactId() );
+        assertEquals( "1.0-SNAPSHOT", gav.getVersion() );
+        assertEquals( "1.0-SNAPSHOT", gav.getBaseVersion() );
+        assertEquals( null, gav.getClassifier() );
+        assertEquals( "pom", gav.getExtension() );
+        assertEquals( "hintmod-1.0-SNAPSHOT.pom", gav.getName() );
+        assertEquals( true, gav.isSnapshot() );
+        assertEquals( false, gav.isHash() );
+        assertEquals( null, gav.getHashType() );
+
+        path = gavCalculator.gavToPath( gav );
+        assertEquals( "/dev/mbien/hintmod/1.0-SNAPSHOT/hintmod-1.0-SNAPSHOT.pom", path );
+
+        gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/1.0-SNAPSHOT/maven-metadata-local.xml" ); // causes MINDEXER-144
+        assertNull( gav );
+        gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/maven-metadata-local.xml" );
+        assertNull( gav );
     }
 
     public void testNegGav()


### PR DESCRIPTION
Scanner throws IOOBEx when scanning local repository
due GAV level locally installed metadata. Filter it
out better (m2gav calculator and context producer).

Added UT that initially reproduced the issue, and now
passes OK.

---

https://issues.apache.org/jira/browse/MINDEXER-144