### PR TITLE
[MINDEXER-147] Move allGroups/rootGroups to in memory only

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -100,7 +100,11 @@ public class IndexDataReader
 
                 rootGroups.add( ai.getRootGroup() );
                 allGroups.add( ai.getGroupId() );
-
+            }
+            else if ( doc.getField( ArtifactInfo.ALL_GROUPS ) != null
+                    || doc.getField( ArtifactInfo.ROOT_GROUPS ) != null )
+            {
+                // skip it
             }
             else
             {

--- a/indexer-core/src/test/java/org/apache/maven/index/packer/NEXUS4149TransferFormatTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/packer/NEXUS4149TransferFormatTest.java
@@ -115,10 +115,13 @@ public class NEXUS4149TransferFormatTest
 
         for ( IndexingContext member : mctx.getMembers() )
         {
-            Assert.assertEquals( "Members should have one root group!", 1, member.getRootGroups().size() );
+            if ( !"repo4".equals( member.getId() ) ) // repo4 is empty
+            {
+                Assert.assertEquals( "Members should have one root group!", 1, member.getRootGroups().size() );
+            }
         }
 
-        Assert.assertEquals( "Merged should have one root multiply members count!", mctx.getMembers().size(),
+        Assert.assertEquals( "Merged should have one root multiply members count (sans repo4)!", 3,
             mctx.getRootGroups().size() );
     }
 


### PR DESCRIPTION
Do not (mis)use Lucene index to store potentially huge
dataset, while this field is really not even searched, it
just contains aggregated artifact groups that are present
on index.

---

https://issues.apache.org/jira/browse/MINDEXER-147