### PR TITLE
[MINDEXER-148] Do not replace CLI

### DIFF
--- a/indexer-cli/pom.xml
+++ b/indexer-cli/pom.xml
@@ -37,7 +37,7 @@ under the License.
     UNWORKABLE! -->
 
   <properties>
-    <shadedClassifier>shaded</shadedClassifier>
+    <cliClassifier>cli</cliClassifier>
   </properties>
 
   <dependencies>
@@ -122,7 +122,7 @@ under the License.
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedClassifierName>${shadedClassifier}</shadedClassifierName>
+              <shadedClassifierName>${cliClassifier}</shadedClassifierName>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>
@@ -167,7 +167,7 @@ under the License.
               <redirectTestOutputToFile>${failsafe.redirectTestOutputToFile}</redirectTestOutputToFile>
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-                <indexerJar>${project.build.directory}/${project.artifactId}-${project.version}-${shadedClassifier}.jar</indexerJar>
+                <indexerJar>${project.build.directory}/${project.artifactId}-${project.version}-${cliClassifier}.jar</indexerJar>
               </systemPropertyVariables>
             </configuration>
           </execution>

--- a/indexer-cli/pom.xml
+++ b/indexer-cli/pom.xml
@@ -36,6 +36,10 @@ under the License.
   <!-- IMPORTANT! * WHEN YOU CHANGE DEPS MAKE SURE TO UPDATE SHADE CONFIG! * DON'T FORGET OTHERWISE YOU ARE RENDERING CLI 
     UNWORKABLE! -->
 
+  <properties>
+    <shadedClassifier>shaded</shadedClassifier>
+  </properties>
+
   <dependencies>
     <!-- The indexer -->
     <dependency>
@@ -118,7 +122,8 @@ under the License.
               <goal>shade</goal>
             </goals>
             <configuration>
-              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <shadedClassifierName>${shadedClassifier}</shadedClassifierName>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>
                 <filter>
@@ -161,7 +166,7 @@ under the License.
               <redirectTestOutputToFile>${failsafe.redirectTestOutputToFile}</redirectTestOutputToFile>
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-                <indexerJar>${project.build.directory}/${project.artifactId}-${project.version}.jar</indexerJar>
+                <indexerJar>${project.build.directory}/${project.artifactId}-${project.version}-${shadedClassifier}.jar</indexerJar>
               </systemPropertyVariables>
             </configuration>
           </execution>


### PR DESCRIPTION
For simplicity sake, the shaded CLI
executable JAR will have a classifier,
instead to replace the main artifact.

This implies GAV of CLI will change,
so is on hold until next major release.

---

https://issues.apache.org/jira/browse/MINDEXER-148