### PR TITLE
[MINDEXER-161] Make project Java 11

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -24,10 +24,9 @@ on:
 jobs:
   build:
     name: Verify
-    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@ff-flags
     with:
-      ff-jdk: '17'
-      ff-site-goal: '-v'
+      ff-run: false
       maven_version: 3.8.5
       jdk-matrix: '[ "17" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Verify
-    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@ff-flags
+    uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
     with:
       ff-run: false
       maven_version: 3.8.5

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -26,6 +26,7 @@ jobs:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
     with:
+      ff-jdk: '17'
       maven_version: 3.8.5
       jdk-matrix: '[ "17" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,6 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
     with:
       ff-jdk: '17'
+      ff-site-goal: '-v'
       maven_version: 3.8.5
       jdk-matrix: '[ "17" ]'
 

--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,5 +25,8 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
+    with:
+      maven_version: 3.8.5
+      jdk-matrix: '[ "17" ]'
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpStdBuild( 'jdks' : [ "8", "11", "17" ] )
+asfMavenTlpStdBuild( 'jdks' : [ "17" ] )

--- a/indexer-cli/src/test/java/org/apache/maven/index/cli/AbstractNexusIndexerCliTest.java
+++ b/indexer-cli/src/test/java/org/apache/maven/index/cli/AbstractNexusIndexerCliTest.java
@@ -80,7 +80,7 @@ public abstract class AbstractNexusIndexerCliTest
         out = new OutputStream()
         {
 
-            private StringBuffer buf = new StringBuffer();
+            private StringBuilder buf = new StringBuilder();
 
             @Override
             public void write( int b )
@@ -95,7 +95,7 @@ public abstract class AbstractNexusIndexerCliTest
             public String toString()
             {
                 String string = buf.toString();
-                buf = new StringBuffer();
+                buf = new StringBuilder();
                 return string;
             }
         };

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -540,8 +541,6 @@ public class DefaultIndexUpdater
     {
         private static final String CHUNKS_FILENAME = "chunks.lst";
 
-        private static final String CHUNKS_FILE_ENCODING = "UTF-8";
-
         private final IndexUpdateResult result;
 
         private final ArrayList<String> newChunks = new ArrayList<>();
@@ -612,7 +611,7 @@ public class DefaultIndexUpdater
         {
             File chunksFile = new File( dir, CHUNKS_FILENAME );
             try ( BufferedOutputStream os = new BufferedOutputStream( new FileOutputStream( chunksFile, true ) ); //
-                            Writer w = new OutputStreamWriter( os, CHUNKS_FILE_ENCODING ) )
+                            Writer w = new OutputStreamWriter( os, StandardCharsets.UTF_8 ) )
             {
                 for ( String filename : newChunks )
                 {
@@ -630,7 +629,8 @@ public class DefaultIndexUpdater
 
             File chunksFile = new File( dir, CHUNKS_FILENAME );
             try ( BufferedReader r =
-                new BufferedReader( new InputStreamReader( new FileInputStream( chunksFile ), CHUNKS_FILE_ENCODING ) ) )
+                new BufferedReader( new InputStreamReader(
+                        new FileInputStream( chunksFile ), StandardCharsets.UTF_8 ) ) )
             {
                 String str;
                 while ( ( str = r.readLine() ) != null )

--- a/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/NexusIndexerTest.java
@@ -25,6 +25,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -334,7 +335,7 @@ public class NexusIndexerTest
         StringWriter ressw = new StringWriter();
         PrintWriter respw = new PrintWriter( ressw );
 
-        BufferedReader reader = new BufferedReader( new FileReader( expectedResults ) );
+        BufferedReader reader = new BufferedReader( new FileReader( expectedResults, StandardCharsets.UTF_8 ) );
         String currentline;
 
         while ( ( currentline = reader.readLine() ) != null )

--- a/indexer-reader/src/test/java/org/apache/maven/index/reader/TestUtils.java
+++ b/indexer-reader/src/test/java/org/apache/maven/index/reader/TestUtils.java
@@ -25,10 +25,9 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static com.google.common.collect.Iterables.concat;
-import static java.util.Collections.singletonList;
 import static org.apache.maven.index.reader.Utils.*;
 
 /**
@@ -60,12 +59,18 @@ public final class TestUtils
   {
     final TreeSet<String> allGroupsSet = new TreeSet<>();
     final TreeSet<String> rootGroupsSet = new TreeSet<>();
-    return StreamSupport.stream(
-            concat( singletonList( descriptor( repoId ) ), iterable, singletonList( allGroups( allGroupsSet ) ),
-                    // placeholder, will be recreated at the end with proper content
-                    singletonList( rootGroups( rootGroupsSet ) )
-                    // placeholder, will be recreated at the end with proper content
-            ).spliterator(), false ).map( rec ->
+    return Stream.concat(
+            Stream.of( descriptor( repoId ) ),
+            Stream.concat(
+                    StreamSupport.stream( iterable.spliterator(), false ),
+                    Stream.concat(
+                            Stream.of( allGroups( allGroupsSet ) ),
+                            // placeholder, will be recreated at the end with proper content
+                            Stream.of( rootGroups( rootGroupsSet ) )
+                    )
+            )
+            // placeholder, will be recreated at the end with proper content
+    ).map( rec ->
     {
       if ( Type.DESCRIPTOR == rec.getType() )
       {

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,12 @@ under the License.
   </distributionManagement>
 
   <properties>
-    <javaVersion>8</javaVersion>
+    <javaVersion>11</javaVersion>
+    <maven.compiler.source>${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>${javaVersion}</maven.compiler.target>
+    <minimalMavenBuildVersion>3.8.5</minimalMavenBuildVersion>
+    <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
+
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <failsafe.redirectTestOutputToFile>true</failsafe.redirectTestOutputToFile>
     <checkstyle.violation.ignore>MagicNumber,ParameterNumber,MethodLength,JavadocType,AvoidNestedBlocks,InterfaceIsType</checkstyle.violation.ignore>
@@ -310,26 +315,6 @@ under the License.
       </plugin>
 
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java1${javaVersion}</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check-java-compat</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <executions>
@@ -368,9 +353,11 @@ under the License.
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>animal-sniffer-maven-plugin</artifactId>
-          <version>1.21</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <release>${javaVersion}</release>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -307,56 +307,26 @@ under the License.
   </modules>
 
   <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
-          <systemPropertyVariables>
-            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
-          </systemPropertyVariables>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>rat-check</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <excludes combine.children="append">
-                <exclude>README.md</exclude>
-                <exclude>.gitignore</exclude>
-                <exclude>NOTICE</exclude>
-                <exclude>**/packageinfo</exclude>
-                <exclude>.git/**</exclude>
-                <exclude>.idea/**</exclude>
-                <exclude>**/*.iml</exclude>
-                <!-- exlude some test resources from rat analysis -->
-                <exclude>src/test/**/*.sha1</exclude>
-                <exclude>src/test/**/*.md5</exclude>
-                <exclude>src/test/**/*.xml</exclude>
-                <exclude>src/test/**/*.pom</exclude>
-                <exclude>src/test/**/*.asc</exclude>
-                <exclude>src/test/**/*.properties</exclude>
-                <exclude>src/test/**/*.swc</exclude>
-                <exclude>src/test/**/*.txt</exclude>
-                <exclude>src/test/**/*.filename</exclude>
-                <exclude>src/test/**/.placeholder</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.gaul</groupId>
+          <artifactId>modernizer-maven-plugin</artifactId>
+          <version>2.4.0</version>
+          <executions>
+            <execution>
+              <id>modernizer</id>
+              <phase>verify</phase>
+              <goals>
+                <goal>modernizer</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <javaVersion>${javaVersion}</javaVersion>
+            <failOnViolations>false</failOnViolations> <!-- TODO: enable this once cleaned up -->
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
@@ -397,6 +367,59 @@ under the License.
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.gaul</groupId>
+        <artifactId>modernizer-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <redirectTestOutputToFile>${surefire.redirectTestOutputToFile}</redirectTestOutputToFile>
+          <systemPropertyVariables>
+            <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.rat</groupId>
+        <artifactId>apache-rat-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>rat-check</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <excludes combine.children="append">
+                <exclude>*.md</exclude>
+                <exclude>.gitignore</exclude>
+                <exclude>NOTICE</exclude>
+                <exclude>**/packageinfo</exclude>
+                <exclude>.git/**</exclude>
+                <exclude>.idea/**</exclude>
+                <exclude>**/*.iml</exclude>
+                <!-- exlude some test resources from rat analysis -->
+                <exclude>src/test/**/*.sha1</exclude>
+                <exclude>src/test/**/*.md5</exclude>
+                <exclude>src/test/**/*.xml</exclude>
+                <exclude>src/test/**/*.pom</exclude>
+                <exclude>src/test/**/*.asc</exclude>
+                <exclude>src/test/**/*.properties</exclude>
+                <exclude>src/test/**/*.swc</exclude>
+                <exclude>src/test/**/*.txt</exclude>
+                <exclude>src/test/**/*.filename</exclude>
+                <exclude>src/test/**/.placeholder</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,6 @@ under the License.
           </executions>
           <configuration>
             <javaVersion>${javaVersion}</javaVersion>
-            <failOnViolations>false</failOnViolations> <!-- TODO: enable this once cleaned up -->
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@ under the License.
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.3</version>
+              <version>10.3</version>
             </dependency>
             <dependency>
               <groupId>org.apache.maven.shared</groupId>

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/Java11HttpClientSmoSearchTransport.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/Java11HttpClientSmoSearchTransport.java
@@ -20,40 +20,46 @@ package org.apache.maven.search.backend.smo.internal;
  */
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Scanner;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
 import org.apache.maven.search.SearchRequest;
 
 /**
- * {@link java.net.HttpURLConnection} backed transport.
+ * Java 11 {@link HttpClient} backed transport.
  */
-public class UrlConnectionSmoSearchTransport extends SmoSearchTransportSupport
+public class Java11HttpClientSmoSearchTransport extends SmoSearchTransportSupport
 {
+    private final HttpClient client = HttpClient.newBuilder().followRedirects( HttpClient.Redirect.NEVER ).build();
+
     @Override
     public String fetch( SearchRequest searchRequest, String serviceUri ) throws IOException
     {
-        HttpURLConnection httpConnection = (HttpURLConnection) new URL( serviceUri ).openConnection();
-        httpConnection.setInstanceFollowRedirects( false );
-        httpConnection.setRequestProperty( "User-Agent", getUserAgent() );
-        httpConnection.setRequestProperty( "Accept", "application/json" );
-        int httpCode = httpConnection.getResponseCode();
-        if ( httpCode == HttpURLConnection.HTTP_OK )
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri( URI.create( serviceUri ) )
+                .header( "User-Agent", getUserAgent() )
+                .header( "Accept", "application/json" )
+                .GET()
+                .build();
+        try
         {
-            try ( InputStream inputStream = httpConnection.getInputStream() )
+            HttpResponse<String> response = client.send( request, HttpResponse.BodyHandlers.ofString() );
+            if ( response.statusCode() == HttpURLConnection.HTTP_OK )
             {
-                try ( Scanner scanner = new Scanner( inputStream, StandardCharsets.UTF_8 ) )
-                {
-                    return scanner.useDelimiter( "\\A" ).next();
-                }
+                return response.body();
+            }
+            else
+            {
+                throw new IOException( "Unexpected response: " + response );
             }
         }
-        else
+        catch ( InterruptedException e )
         {
-            throw new IOException( "Unexpected response code: " + httpCode );
+            Thread.currentThread().interrupt();
+            throw new IOException( e );
         }
     }
 }

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
@@ -153,9 +153,9 @@ public class SmoSearchBackendImpl extends SearchBackendSupport implements SmoSea
         return encodeQueryParameterValue( query.getValue() );
     }
 
-    private String encodeQueryParameterValue( String parameterValue ) throws UnsupportedEncodingException
+    private String encodeQueryParameterValue( String parameterValue )
     {
-        return URLEncoder.encode( parameterValue, StandardCharsets.UTF_8.name() )
+        return URLEncoder.encode( parameterValue, StandardCharsets.UTF_8 )
                 .replace( "+", "%20" );
     }
 

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
@@ -82,7 +82,7 @@ public class SmoSearchBackendImpl extends SearchBackendSupport implements SmoSea
      */
     public SmoSearchBackendImpl()
     {
-        this( DEFAULT_BACKEND_ID, DEFAULT_REPOSITORY_ID, DEFAULT_SMO_URI, new UrlConnectionSmoSearchTransport() );
+        this( DEFAULT_BACKEND_ID, DEFAULT_REPOSITORY_ID, DEFAULT_SMO_URI, new Java11HttpClientSmoSearchTransport() );
     }
 
     /**

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/UrlConnectionSmoSearchTransport.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/UrlConnectionSmoSearchTransport.java
@@ -45,7 +45,7 @@ public class UrlConnectionSmoSearchTransport extends SmoSearchTransportSupport
         {
             try ( InputStream inputStream = httpConnection.getInputStream() )
             {
-                try ( Scanner scanner = new Scanner( inputStream, StandardCharsets.UTF_8.name() ) )
+                try ( Scanner scanner = new Scanner( inputStream, StandardCharsets.UTF_8 ) )
                 {
                     return scanner.useDelimiter( "\\A" ).next();
                 }


### PR DESCRIPTION
Changes:
- requires latest Java LTS to build
- requires latest Maven to build
- uses `--release` to set Java 11 level
- drop animal sniffer as JDK does all now

The goal is to keep project stick to latest LTS Java, latest Maven
and then target the required Java level using new release switch.

---

https://issues.apache.org/jira/browse/MINDEXER-161