### PR TITLE
[MINDEXER-157] After import all groups and root groups are inverted in the IndexingContext

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -231,7 +231,7 @@ public class DefaultIndexUpdater
             }
             else
             {
-                updateRequest.getIndexingContext().replace( directory, rootGroups, allGroups );
+                updateRequest.getIndexingContext().replace( directory, allGroups, rootGroups );
             }
             if ( sideEffects != null && sideEffects.size() > 0 )
             {


### PR DESCRIPTION
The order or the last two arguments of the call to
IndexingContext#replace should be "allGroups, rootGroups", but is
called as "rootGroups, allGroups", leading to the wrong contents
of the corresponding fields of the IndexingContext.