### PR TITLE
[MINDEXER-162] Update Lucene to 9.2

### DIFF
--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -71,7 +71,7 @@ under the License.
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-analyzers-common</artifactId>
+      <artifactId>lucene-analysis-common</artifactId>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ under the License.
 
     <eclipse-sisu.version>0.3.5</eclipse-sisu.version>
     <guice.version>5.1.0</guice.version>
-    <lucene.version>8.11.1</lucene.version>
+    <lucene.version>9.2.0</lucene.version>
     <maven.version>3.8.5</maven.version>
     <resolver.version>1.8.0</resolver.version>
     <archetype.version>3.2.1</archetype.version>
@@ -202,7 +202,7 @@ under the License.
 
       <dependency>
         <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-analyzers-common</artifactId>
+        <artifactId>lucene-analysis-common</artifactId>
         <version>${lucene.version}</version>
       </dependency>
 


### PR DESCRIPTION
Now that indexer is Java11, upgrade to latest Lucene can happen.

---

https://issues.apache.org/jira/browse/MINDEXER-162