### PR TITLE
[MINDEXER-164] Fix IOOBEx on GAV remote repositories

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultArtifactContextProducer.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultArtifactContextProducer.java
@@ -145,6 +145,7 @@ public class DefaultArtifactContextProducer
 
         return !filename.equals( "maven-metadata.xml" )
                 && !( filename.startsWith( "maven-metadata-" ) && filename.endsWith( ".xml" ) )
+                && !( filename.startsWith( "_" ) && filename.endsWith( ".repositories" ) )
                 // || filename.endsWith( "-javadoc.jar" )
                 // || filename.endsWith( "-javadocs.jar" )
                 // || filename.endsWith( "-sources.jar" )

--- a/indexer-core/src/main/java/org/apache/maven/index/artifact/M2GavCalculator.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/artifact/M2GavCalculator.java
@@ -92,7 +92,8 @@ public class M2GavCalculator
             }
 
             if ( s.endsWith( "maven-metadata.xml" )
-                    || ( fileName.startsWith( "maven-metadata-" ) && fileName.contains( ".xml" ) ) )
+                    || ( fileName.startsWith( "maven-metadata-" ) && fileName.contains( ".xml" ) )
+                    || ( fileName.startsWith( "_" ) && fileName.endsWith( ".repositories" ) ) )
             {
                 return null;
             }

--- a/indexer-core/src/test/java/org/apache/maven/index/artifact/M2GavCalculatorTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/artifact/M2GavCalculatorTest.java
@@ -585,6 +585,10 @@ public class M2GavCalculatorTest
         assertNull( gav );
         gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/maven-metadata-local.xml" );
         assertNull( gav );
+        gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/1.0-SNAPSHOT/_remote.repositories" ); // causes MINDEXER-164
+        assertNull( gav );
+        gav = gavCalculator.pathToGav( "/dev/mbien/hintmod/1.0-SNAPSHOT/_maven.repositories" );
+        assertNull( gav );
     }
 
     public void testNegGav()


### PR DESCRIPTION
This is a follow-up on https://github.com/apache/maven-indexer/pull/198 and [MINDEXER-144](https://issues.apache.org/jira/browse/MINDEXER-144), which only fixed the IndexOutOfBound issues for some file types.

The exception can still happen if the local repository contains `_remote.repository` or similar files. Apparently, with Maven 3.0.x, maven creates these file to record where the file was resolved from ([source](https://stackoverflow.com/a/16870552/3388748)).

<details>
  <summary>Full stacktrace for reference:</summary>

```
Caused by: java.lang.IndexOutOfBoundsException: start 56, end 64, length 57
	at java.base/java.lang.AbstractStringBuilder.checkRange(AbstractStringBuilder.java:1794)
	at java.base/java.lang.AbstractStringBuilder.append(AbstractStringBuilder.java:675)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:217)
	at org.apache.maven.index.artifact.M2GavCalculator.getSnapshotGav(M2GavCalculator.java:188)
	at org.apache.maven.index.artifact.M2GavCalculator.pathToGav(M2GavCalculator.java:104)
	at org.apache.maven.index.DefaultArtifactContextProducer.getGavFromPath(DefaultArtifactContextProducer.java:160)
	at org.apache.maven.index.DefaultArtifactContextProducer.getArtifactContext(DefaultArtifactContextProducer.java:83)
	at org.apache.maven.index.DefaultScanner.processFile(DefaultScanner.java:109)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:99)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:91)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:91)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:91)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:91)
	at org.apache.maven.index.DefaultScanner.scanDirectory(DefaultScanner.java:91)
	at org.apache.maven.index.DefaultScanner.scan(DefaultScanner.java:60)
	at org.apache.maven.index.DefaultNexusIndexer.scan(DefaultNexusIndexer.java:291)
	... 8 more
```

</details>

---

https://issues.apache.org/jira/browse/MINDEXER-164