### PR TITLE
[MINDEXER-151] Speed up Index update from remote

### DIFF
--- a/indexer-cli/src/main/java/org/apache/maven/index/cli/NexusIndexerCli.java
+++ b/indexer-cli/src/main/java/org/apache/maven/index/cli/NexusIndexerCli.java
@@ -528,10 +528,11 @@ public class NexusIndexerCli
 
         final List<IndexCreator> indexers = getIndexers( cli, components );
 
+
         try ( BufferedInputStream is = new BufferedInputStream( new FileInputStream( indexArchive ) ); //
               FSDirectory directory = FSDirectory.open( outputFolder.toPath() ) )
         {
-            DefaultIndexUpdater.unpackIndexData( is, directory, (IndexingContext) Proxy.newProxyInstance(
+            DefaultIndexUpdater.unpackIndexData( is, 4, directory, (IndexingContext) Proxy.newProxyInstance(
                     getClass().getClassLoader(), new Class[] {IndexingContext.class}, new PartialImplementation()
                     {
                         public List<IndexCreator> getIndexCreators()

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -209,7 +209,8 @@ public class DefaultIndexUpdater
             Set<String> allGroups;
             if ( remoteIndexFile.endsWith( ".gz" ) )
             {
-                IndexDataReadResult result = unpackIndexData( is, directory, updateRequest.getIndexingContext() );
+                IndexDataReadResult result = unpackIndexData( is, updateRequest.getThreads(), directory,
+                        updateRequest.getIndexingContext() );
                 timestamp = result.getTimestamp();
                 rootGroups = result.getRootGroups();
                 allGroups = result.getAllGroups();
@@ -380,17 +381,20 @@ public class DefaultIndexUpdater
 
     /**
      * @param is an input stream to unpack index data from
+     * @param threads thread count to use
      * @param d
      * @param context
      */
-    public static IndexDataReadResult unpackIndexData( final InputStream is, final Directory d,
+    public static IndexDataReadResult unpackIndexData( final InputStream is, final int threads, final Directory d,
                                                        final IndexingContext context )
         throws IOException
     {
-        NexusIndexWriter w = new NexusIndexWriter( d, new IndexWriterConfig( new NexusAnalyzer() ) );
+        IndexWriterConfig config = new IndexWriterConfig( new NexusAnalyzer() );
+        config.setUseCompoundFile( false );
+        NexusIndexWriter w = new NexusIndexWriter( d, config );
         try
         {
-            IndexDataReader dr = new IndexDataReader( is );
+            IndexDataReader dr = new IndexDataReader( is, threads );
 
             return dr.readIndex( w, context );
         }

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -77,9 +77,9 @@ public class IndexDataReader
     public IndexDataReader( final InputStream is, final int threads )
             throws IOException
     {
-        if ( threads < 1 || threads > 16 )
+        if ( threads < 1 )
         {
-            throw new IllegalArgumentException( "Threads allowed between 1-16, we got: " + threads );
+            throw new IllegalArgumentException( "Reader threads must be greater than zero: " + threads );
         }
         this.threads = threads;
         // MINDEXER-13

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexUpdateRequest.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexUpdateRequest.java
@@ -55,6 +55,8 @@ public class IndexUpdateRequest
 
     private FSDirectoryFactory directoryFactory;
 
+    private int threads;
+
     public IndexUpdateRequest( final IndexingContext context, final ResourceFetcher resourceFetcher )
     {
         assert context != null : "Context to be updated cannot be null!";
@@ -64,6 +66,7 @@ public class IndexUpdateRequest
         this.resourceFetcher = resourceFetcher;
         this.forceFullUpdate = false;
         this.incrementalOnly = false;
+        this.threads = 1;
     }
 
     public IndexingContext getIndexingContext()
@@ -164,5 +167,15 @@ public class IndexUpdateRequest
     public File getIndexTempDir()
     {
         return indexTempDir;
+    }
+
+    public int getThreads()
+    {
+        return threads;
+    }
+
+    public void setThreads( int threads )
+    {
+        this.threads = threads;
     }
 }

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
@@ -88,7 +88,7 @@ public class IndexDataTest
 
         newDir = new ByteBuffersDirectory();
 
-        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context ).getTimestamp();
+        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, 1, newDir, context ).getTimestamp();
 
         assertEquals( timestamp, newTimestamp );
 
@@ -126,7 +126,7 @@ public class IndexDataTest
 
         newDir = new ByteBuffersDirectory();
 
-        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, newDir, context ).getTimestamp();
+        Date newTimestamp = DefaultIndexUpdater.unpackIndexData( is, 1, newDir, context ).getTimestamp();
 
         assertEquals( null, newTimestamp );
 

--- a/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/index/examples/BasicUsageExample.java
+++ b/indexer-examples/indexer-examples-basic/src/main/java/org/apache/maven/index/examples/BasicUsageExample.java
@@ -129,6 +129,7 @@ public class BasicUsageExample
             Instant updateStart = Instant.now();
             System.out.println( "Updating Index..." );
             System.out.println( "This might take a while on first run, so please be patient!" );
+
             Date centralContextCurrentTimestamp = centralContext.getTimestamp();
             IndexUpdateRequest updateRequest = new IndexUpdateRequest( centralContext, new Java11HttpClient() );
             IndexUpdateResult updateResult = indexUpdater.fetchAndUpdateIndex( updateRequest );


### PR DESCRIPTION
Introduce MT index update, allow users to specify the count of threads/silos to use while importing index. Without code change threads = 1 and there is no change in codepath (everything works as before).

This change (ingesting GZIP files raw records into Lucene index on multiple threads) on my PC halves the execution time: while BasicUsageExample on master takes over 15 minutes to finish (when doing full update), this PR makes it under 7 minutes when using 4 threads.

---

https://issues.apache.org/jira/browse/MINDEXER-151