### PR TITLE
[MINDEXER-173] Make Search API and SMO backend Java8

### DIFF
--- a/search-api/pom.xml
+++ b/search-api/pom.xml
@@ -33,6 +33,10 @@ under the License.
     Indexer Search API.
   </description>
 
+  <properties>
+    <javaVersion>8</javaVersion>
+  </properties>
+
   <dependencies>
     <!-- Test -->
     <dependency>

--- a/search-backend-indexer/src/main/java/org/apache/maven/search/backend/indexer/IndexerCoreSearchBackendFactory.java
+++ b/search-backend-indexer/src/main/java/org/apache/maven/search/backend/indexer/IndexerCoreSearchBackendFactory.java
@@ -19,22 +19,29 @@ package org.apache.maven.search.backend.indexer;
  * under the License.
  */
 
-import java.io.IOException;
-
+import org.apache.maven.index.Indexer;
 import org.apache.maven.index.context.IndexingContext;
-import org.apache.maven.search.SearchBackend;
-import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.indexer.internal.IndexerCoreSearchBackendImpl;
+
+import static java.util.Objects.requireNonNull;
 
 /**
- * The Indexer Core search backend.
+ * The Indexer Core search backend factory.
  */
-public interface IndexerCoreSearchBackend extends SearchBackend
+public class IndexerCoreSearchBackendFactory
 {
-    @Override
-    IndexerCoreSearchResponse search( SearchRequest searchRequest ) throws IOException;
+    private final Indexer indexer;
+
+    public IndexerCoreSearchBackendFactory( Indexer indexer )
+    {
+        this.indexer = requireNonNull( indexer, "indexer cannot be null" );
+    }
 
     /**
-     * Returns the {@link IndexingContext} used by this search backend, never {@code null}.
+     * Creates {@link IndexerCoreSearchBackend} instance using passed in context.
      */
-    IndexingContext getIndexingContext();
+    public IndexerCoreSearchBackend createIndexerCoreSearchBackend( IndexingContext indexingContext )
+    {
+        return new IndexerCoreSearchBackendImpl( indexer, indexingContext );
+    }
 }

--- a/search-backend-indexer/src/test/java/org/apache/maven/search/backend/indexer/internal/IndexerCoreSearchBackendImplTest.java
+++ b/search-backend-indexer/src/test/java/org/apache/maven/search/backend/indexer/internal/IndexerCoreSearchBackendImplTest.java
@@ -49,6 +49,8 @@ import org.apache.maven.search.MAVEN;
 import org.apache.maven.search.Record;
 import org.apache.maven.search.SearchRequest;
 import org.apache.maven.search.SearchResponse;
+import org.apache.maven.search.backend.indexer.IndexerCoreSearchBackend;
+import org.apache.maven.search.backend.indexer.IndexerCoreSearchBackendFactory;
 import org.apache.maven.search.request.FieldQuery;
 import org.eclipse.sisu.launch.InjectedTest;
 import org.junit.After;
@@ -74,7 +76,7 @@ public class IndexerCoreSearchBackendImplTest extends InjectedTest
 
     private IndexingContext centralContext;
 
-    private IndexerCoreSearchBackendImpl backend;
+    private IndexerCoreSearchBackend backend;
 
     private void dumpSingle( AtomicInteger counter, List<Record> page )
     {
@@ -185,7 +187,7 @@ public class IndexerCoreSearchBackendImplTest extends InjectedTest
         System.out.println( "Done in " + Duration.ofMillis( System.currentTimeMillis() - start ) );
         System.out.println();
 
-        this.backend = new IndexerCoreSearchBackendImpl( indexer, centralContext );
+        this.backend = new IndexerCoreSearchBackendFactory( indexer ).createIndexerCoreSearchBackend( centralContext );
     }
 
     @After

--- a/search-backend-smo/pom.xml
+++ b/search-backend-smo/pom.xml
@@ -33,6 +33,10 @@ under the License.
     Indexer Search Backend implemented by SMO.
   </description>
 
+  <properties>
+    <javaVersion>8</javaVersion>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.indexer</groupId>
@@ -66,6 +70,39 @@ under the License.
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>compile-java-11</id>
+            <phase>compile</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <release>11</release>
+              <compileSourceRoots>
+                <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+              </compileSourceRoots>
+              <multiReleaseOutput>true</multiReleaseOutput>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackend.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackend.java
@@ -19,13 +19,19 @@ package org.apache.maven.search.backend.smo;
  * under the License.
  */
 
+import java.io.IOException;
+
 import org.apache.maven.search.SearchBackend;
+import org.apache.maven.search.SearchRequest;
 
 /**
  * The SMO search backend.
  */
 public interface SmoSearchBackend extends SearchBackend
 {
+    @Override
+    SmoSearchResponse search( SearchRequest searchRequest ) throws IOException;
+
     /**
      * Returns the base "service URI" that is used by this SMO backend. never {@code null}.
      */

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackendFactory.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackendFactory.java
@@ -1,0 +1,55 @@
+package org.apache.maven.search.backend.smo;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.search.backend.smo.internal.SmoSearchBackendImpl;
+import org.apache.maven.search.backend.smo.internal.SmoSearchTransportProvider;
+
+/**
+ * The SMO search backend factory.
+ */
+public class SmoSearchBackendFactory
+{
+    public static final String DEFAULT_BACKEND_ID = "central-smo";
+
+    public static final String DEFAULT_REPOSITORY_ID = "central";
+
+    public static final String DEFAULT_SMO_URI = "https://search.maven.org/solrsearch/select";
+
+    /**
+     * Creates "default" SMO search backend suitable for most use cases.
+     */
+    public SmoSearchBackend createDefault()
+    {
+        return create( DEFAULT_BACKEND_ID, DEFAULT_REPOSITORY_ID, DEFAULT_SMO_URI,
+                new SmoSearchTransportProvider().get() );
+    }
+
+    /**
+     * Creates SMO search backend using provided parameters.
+     */
+    public SmoSearchBackend create( String backendId,
+                                    String repositoryId,
+                                    String smoUri,
+                                    SmoSearchTransportSupport transportSupport )
+    {
+        return new SmoSearchBackendImpl( backendId, repositoryId, smoUri, transportSupport );
+    }
+}

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackendFactory.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchBackendFactory.java
@@ -20,7 +20,7 @@ package org.apache.maven.search.backend.smo;
  */
 
 import org.apache.maven.search.backend.smo.internal.SmoSearchBackendImpl;
-import org.apache.maven.search.backend.smo.internal.SmoSearchTransportProvider;
+import org.apache.maven.search.backend.smo.internal.SmoSearchTransportSupplier;
 
 /**
  * The SMO search backend factory.
@@ -39,7 +39,7 @@ public class SmoSearchBackendFactory
     public SmoSearchBackend createDefault()
     {
         return create( DEFAULT_BACKEND_ID, DEFAULT_REPOSITORY_ID, DEFAULT_SMO_URI,
-                new SmoSearchTransportProvider().get() );
+                new SmoSearchTransportSupplier().get() );
     }
 
     /**

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchTransportSupport.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/SmoSearchTransportSupport.java
@@ -1,4 +1,4 @@
-package org.apache.maven.search.backend.smo.internal;
+package org.apache.maven.search.backend.smo;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImpl.java
@@ -40,6 +40,7 @@ import org.apache.maven.search.Record;
 import org.apache.maven.search.SearchRequest;
 import org.apache.maven.search.backend.smo.SmoSearchBackend;
 import org.apache.maven.search.backend.smo.SmoSearchResponse;
+import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 import org.apache.maven.search.request.BooleanQuery;
 import org.apache.maven.search.request.Field;
 import org.apache.maven.search.request.FieldQuery;
@@ -51,12 +52,6 @@ import static java.util.Objects.requireNonNull;
 
 public class SmoSearchBackendImpl extends SearchBackendSupport implements SmoSearchBackend
 {
-    public static final String DEFAULT_BACKEND_ID = "central-smo";
-
-    public static final String DEFAULT_REPOSITORY_ID = "central";
-
-    public static final String DEFAULT_SMO_URI = "https://search.maven.org/solrsearch/select";
-
     private static final Map<Field, String> FIELD_TRANSLATION;
 
     static
@@ -76,14 +71,6 @@ public class SmoSearchBackendImpl extends SearchBackendSupport implements SmoSea
     private final String smoUri;
 
     private final SmoSearchTransportSupport transportSupport;
-
-    /**
-     * Creates a "default" instance of SMO backend against {@link #DEFAULT_SMO_URI}.
-     */
-    public SmoSearchBackendImpl()
-    {
-        this( DEFAULT_BACKEND_ID, DEFAULT_REPOSITORY_ID, DEFAULT_SMO_URI, new Java11HttpClientSmoSearchTransport() );
-    }
 
     /**
      * Creates a customized instance of SMO backend, like an in-house instances of SMO or different IDs.
@@ -155,8 +142,15 @@ public class SmoSearchBackendImpl extends SearchBackendSupport implements SmoSea
 
     private String encodeQueryParameterValue( String parameterValue )
     {
-        return URLEncoder.encode( parameterValue, StandardCharsets.UTF_8 )
-                .replace( "+", "%20" );
+        try
+        {
+            return URLEncoder.encode( parameterValue, StandardCharsets.UTF_8.name() )
+                    .replace( "+", "%20" );
+        }
+        catch ( UnsupportedEncodingException e )
+        {
+            throw new RuntimeException( e );
+        }
     }
 
     private int populateFromRaw( JsonObject raw, List<Record> page )

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchTransportProvider.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchTransportProvider.java
@@ -1,4 +1,4 @@
-package org.apache.maven.search.backend.indexer;
+package org.apache.maven.search.backend.smo.internal;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,22 +19,18 @@ package org.apache.maven.search.backend.indexer;
  * under the License.
  */
 
-import java.io.IOException;
+import java.util.function.Supplier;
 
-import org.apache.maven.index.context.IndexingContext;
-import org.apache.maven.search.SearchBackend;
-import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 
 /**
- * The Indexer Core search backend.
+ * Transport supplier.
  */
-public interface IndexerCoreSearchBackend extends SearchBackend
+public class SmoSearchTransportProvider implements Supplier<SmoSearchTransportSupport>
 {
     @Override
-    IndexerCoreSearchResponse search( SearchRequest searchRequest ) throws IOException;
-
-    /**
-     * Returns the {@link IndexingContext} used by this search backend, never {@code null}.
-     */
-    IndexingContext getIndexingContext();
+    public SmoSearchTransportSupport get()
+    {
+        return new UrlConnectionSmoSearchTransport();
+    }
 }

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchTransportSupplier.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/SmoSearchTransportSupplier.java
@@ -26,11 +26,11 @@ import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 /**
  * Transport supplier.
  */
-public class SmoSearchTransportProvider implements Supplier<SmoSearchTransportSupport>
+public class SmoSearchTransportSupplier implements Supplier<SmoSearchTransportSupport>
 {
     @Override
     public SmoSearchTransportSupport get()
     {
-        return new Java11HttpClientSmoSearchTransport();
+        return new UrlConnectionSmoSearchTransport();
     }
 }

--- a/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/UrlConnectionSmoSearchTransport.java
+++ b/search-backend-smo/src/main/java/org/apache/maven/search/backend/smo/internal/UrlConnectionSmoSearchTransport.java
@@ -1,0 +1,60 @@
+package org.apache.maven.search.backend.smo.internal;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
+
+/**
+ * {@link java.net.HttpURLConnection} backed transport.
+ */
+public class UrlConnectionSmoSearchTransport extends SmoSearchTransportSupport
+{
+    @Override
+    public String fetch( SearchRequest searchRequest, String serviceUri ) throws IOException
+    {
+        HttpURLConnection httpConnection = (HttpURLConnection) new URL( serviceUri ).openConnection();
+        httpConnection.setInstanceFollowRedirects( false );
+        httpConnection.setRequestProperty( "User-Agent", getUserAgent() );
+        httpConnection.setRequestProperty( "Accept", "application/json" );
+        int httpCode = httpConnection.getResponseCode();
+        if ( httpCode == HttpURLConnection.HTTP_OK )
+        {
+            try ( InputStream inputStream = httpConnection.getInputStream() )
+            {
+                try ( Scanner scanner = new Scanner( inputStream, StandardCharsets.UTF_8.name() ) )
+                {
+                    return scanner.useDelimiter( "\\A" ).next();
+                }
+            }
+        }
+        else
+        {
+            throw new IOException( "Unexpected response code: " + httpCode );
+        }
+    }
+}

--- a/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/Java11HttpClientSmoSearchTransport.java
+++ b/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/Java11HttpClientSmoSearchTransport.java
@@ -27,6 +27,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 
 /**
  * Java 11 {@link HttpClient} backed transport.

--- a/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/SmoSearchTransportProvider.java
+++ b/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/SmoSearchTransportProvider.java
@@ -1,4 +1,4 @@
-package org.apache.maven.search.backend.indexer;
+package org.apache.maven.search.backend.smo.internal;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -19,22 +19,18 @@ package org.apache.maven.search.backend.indexer;
  * under the License.
  */
 
-import java.io.IOException;
+import java.util.function.Supplier;
 
-import org.apache.maven.index.context.IndexingContext;
-import org.apache.maven.search.SearchBackend;
-import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 
 /**
- * The Indexer Core search backend.
+ * Transport supplier.
  */
-public interface IndexerCoreSearchBackend extends SearchBackend
+public class SmoSearchTransportProvider implements Supplier<SmoSearchTransportSupport>
 {
     @Override
-    IndexerCoreSearchResponse search( SearchRequest searchRequest ) throws IOException;
-
-    /**
-     * Returns the {@link IndexingContext} used by this search backend, never {@code null}.
-     */
-    IndexingContext getIndexingContext();
+    public SmoSearchTransportSupport get()
+    {
+        return new Java11HttpClientSmoSearchTransport();
+    }
 }

--- a/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/SmoSearchTransportSupplier.java
+++ b/search-backend-smo/src/main/java11/org/apache/maven/search/backend/smo/internal/SmoSearchTransportSupplier.java
@@ -26,11 +26,11 @@ import org.apache.maven.search.backend.smo.SmoSearchTransportSupport;
 /**
  * Transport supplier.
  */
-public class SmoSearchTransportProvider implements Supplier<SmoSearchTransportSupport>
+public class SmoSearchTransportSupplier implements Supplier<SmoSearchTransportSupport>
 {
     @Override
     public SmoSearchTransportSupport get()
     {
-        return new UrlConnectionSmoSearchTransport();
+        return new Java11HttpClientSmoSearchTransport();
     }
 }

--- a/search-backend-smo/src/test/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImplTest.java
+++ b/search-backend-smo/src/test/java/org/apache/maven/search/backend/smo/internal/SmoSearchBackendImplTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.maven.search.MAVEN;
 import org.apache.maven.search.Record;
 import org.apache.maven.search.SearchRequest;
+import org.apache.maven.search.backend.smo.SmoSearchBackend;
+import org.apache.maven.search.backend.smo.SmoSearchBackendFactory;
 import org.apache.maven.search.backend.smo.SmoSearchResponse;
 import org.apache.maven.search.request.BooleanQuery;
 import org.apache.maven.search.request.FieldQuery;
@@ -38,7 +40,7 @@ import org.junit.Test;
 @Ignore( "This is not a test, is more a showcase" )
 public class SmoSearchBackendImplTest
 {
-    private final SmoSearchBackendImpl backend = new SmoSearchBackendImpl();
+    private final SmoSearchBackend backend = new SmoSearchBackendFactory().createDefault();
 
     private void dumpSingle( AtomicInteger counter, List<Record> page )
     {


### PR DESCRIPTION
There is nothing special with them, but provide
alt transport for Java11. The Indexer backend MUST be Java11 as it directly uses Indexer that is Java11.

---

https://issues.apache.org/jira/browse/MINDEXER-173