### PR TITLE
[MINDEXER-181] IndexDataReader should use Sets

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -31,10 +31,10 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -133,8 +133,8 @@ public class IndexDataReader
         int n = 0;
 
         Document doc;
-        ConcurrentMap<String, Boolean> rootGroups = new ConcurrentHashMap<>();
-        ConcurrentMap<String, Boolean> allGroups = new ConcurrentHashMap<>();
+        Set<String> rootGroups = new HashSet<>();
+        Set<String> allGroups = new HashSet<>();
 
         while ( ( doc = readDocument() ) != null )
         {
@@ -147,8 +147,8 @@ public class IndexDataReader
         IndexDataReadResult result = new IndexDataReadResult();
         result.setDocumentCount( n );
         result.setTimestamp( date );
-        result.setRootGroups( rootGroups.keySet() );
-        result.setAllGroups( allGroups.keySet() );
+        result.setRootGroups( rootGroups );
+        result.setAllGroups( allGroups );
 
         LOGGER.debug( "Reading ST index done in {} sec", Duration.between( start, Instant.now() ).getSeconds() );
         return result;
@@ -165,8 +165,8 @@ public class IndexDataReader
 
         final Document theEnd = new Document();
 
-        ConcurrentMap<String, Boolean> rootGroups = new ConcurrentHashMap<>();
-        ConcurrentMap<String, Boolean> allGroups = new ConcurrentHashMap<>();
+        Set<String> rootGroups = ConcurrentHashMap.newKeySet();
+        Set<String> allGroups = ConcurrentHashMap.newKeySet();
         ArrayBlockingQueue<Document> queue = new ArrayBlockingQueue<>( 10000 );
 
         ExecutorService executorService = Executors.newFixedThreadPool( threads );
@@ -257,8 +257,8 @@ public class IndexDataReader
         IndexDataReadResult result = new IndexDataReadResult();
         result.setDocumentCount( n );
         result.setTimestamp( date );
-        result.setRootGroups( rootGroups.keySet() );
-        result.setAllGroups( allGroups.keySet() );
+        result.setRootGroups( rootGroups );
+        result.setAllGroups( allGroups );
 
         LOGGER.debug( "Reading MT index done in {} sec", Duration.between( start, Instant.now() ).getSeconds() );
         return result;
@@ -277,8 +277,8 @@ public class IndexDataReader
     }
 
     private void addToIndex( final Document doc, final IndexingContext context, final IndexWriter indexWriter,
-                             final ConcurrentMap<String, Boolean> rootGroups,
-                             final ConcurrentMap<String, Boolean> allGroups )
+                             final Set<String> rootGroups,
+                             final Set<String> allGroups )
             throws IOException
     {
         ArtifactInfo ai = IndexUtils.constructArtifactInfo( doc, context );
@@ -286,8 +286,8 @@ public class IndexDataReader
         {
             indexWriter.addDocument( IndexUtils.updateDocument( doc, context, false, ai ) );
 
-            rootGroups.putIfAbsent( ai.getRootGroup(), Boolean.TRUE );
-            allGroups.putIfAbsent( ai.getGroupId(), Boolean.TRUE );
+            rootGroups.add( ai.getRootGroup() );
+            allGroups.add( ai.getGroupId() );
         }
         else
         {


### PR DESCRIPTION
Noticed that both, the single threaded and the multi threaded impl used CHMs. Instead of only changing `readIndexST` to plain `Map`s, I switched everything to `Set`s.

---

https://issues.apache.org/jira/browse/MINDEXER-181