### PR TITLE
[MINDEXER-183] Upgrade key dependencies

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,7 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v2
     with:
       ff-run: false
-      maven_version: 3.8.6
+      maven_version: 3.8.7
       jdk-matrix: '[ "17" ]'
 
 

--- a/indexer-cli/pom.xml
+++ b/indexer-cli/pom.xml
@@ -118,6 +118,7 @@ under the License.
                   <artifact>*:*</artifact>
                   <excludes>
                     <exclude>module-info.class</exclude>
+                    <exclude>META-INF/versions/9/module-info.class</exclude>
                     <exclude>META-INF/*.SF</exclude>
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>

--- a/indexer-examples/indexer-examples-spring/pom.xml
+++ b/indexer-examples/indexer-examples-spring/pom.xml
@@ -33,7 +33,7 @@ under the License.
   <description>This module contains Maven Indexer usage examples for integration with Spring.</description>
 
   <properties>
-    <version.spring>5.3.23</version.spring>
+    <version.spring>5.3.25</version.spring>
   </properties>
 
   <dependencies>

--- a/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/index/examples/indexing/RepositoryIndexerFactory.java
+++ b/indexer-examples/indexer-examples-spring/src/main/java/org/apache/maven/index/examples/indexing/RepositoryIndexerFactory.java
@@ -29,6 +29,7 @@ import org.apache.maven.index.Indexer;
 import org.apache.maven.index.Scanner;
 import org.apache.maven.index.context.IndexCreator;
 import org.apache.maven.index.context.IndexingContext;
+import org.springframework.stereotype.Component;
 
 /**
  * A factory for pre-configured RepositoryIndexers.
@@ -36,6 +37,7 @@ import org.apache.maven.index.context.IndexingContext;
  * @author mtodorov
  */
 @Singleton
+@Component
 public class RepositoryIndexerFactory {
 
     private IndexerConfiguration indexerConfiguration;

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@ under the License.
     <javaVersion>11</javaVersion>
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
-    <minimalMavenBuildVersion>3.8.6</minimalMavenBuildVersion>
+    <minimalMavenBuildVersion>3.8.7</minimalMavenBuildVersion>
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
 
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
@@ -104,14 +104,14 @@ under the License.
 
     <eclipse-sisu.version>0.3.5</eclipse-sisu.version>
     <guice.version>5.1.0</guice.version>
-    <lucene.version>9.4.2</lucene.version>
-    <maven.version>3.8.6</maven.version>
-    <resolver.version>1.9.2</resolver.version>
+    <lucene.version>9.5.0</lucene.version>
+    <maven.version>3.8.7</maven.version>
+    <resolver.version>1.9.4</resolver.version>
     <archetype.version>3.2.1</archetype.version>
-    <surefire.version>3.0.0-M7</surefire.version>
-    <slf4j.version>1.7.36</slf4j.version>
+    <surefire.version>3.0.0-M8</surefire.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <maven.site.path>maven-indexer-archives/maven-indexer-LATEST</maven.site.path>
-    <project.build.outputTimestamp>2022-11-08T14:20:48Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2023-01-31T17:00:00Z</project.build.outputTimestamp>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,18 @@ under the License.
     <pluginManagement>
       <plugins>
         <plugin>
+          <!-- remove once parent POM updated -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
+          <!-- remove once parent POM updated -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>3.1.0</version>
+        </plugin>
+        <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
           <version>2.5.0</version>

--- a/search-backend-smo/pom.xml
+++ b/search-backend-smo/pom.xml
@@ -45,7 +45,7 @@ under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.10</version>
+      <version>2.10.1</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
Updates:
 * lucene to 9.5.0
 * slf4j for 2.0.6
 * maven to 3.8.7
 * resolver to 1.9.4
 * (search-smo) gson to 2.10.1
 * (build) surefire to 3.0.0-M8
 * (examples) springframework to 5.3.25 (and fix example, it was broken)

---

https://issues.apache.org/jira/browse/MINDEXER-183