### PR TITLE
[MINDEXER-184] Update resolver to 1.9.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
     <guice.version>5.1.0</guice.version>
     <lucene.version>9.5.0</lucene.version>
     <maven.version>3.8.7</maven.version>
-    <resolver.version>1.9.5-SNAPSHOT</resolver.version>
+    <resolver.version>1.9.5</resolver.version>
     <archetype.version>3.2.1</archetype.version>
     <surefire.version>3.0.0-M8</surefire.version>
     <slf4j.version>2.0.6</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
     <guice.version>5.1.0</guice.version>
     <lucene.version>9.5.0</lucene.version>
     <maven.version>3.8.7</maven.version>
-    <resolver.version>1.9.4</resolver.version>
+    <resolver.version>1.9.5-SNAPSHOT</resolver.version>
     <archetype.version>3.2.1</archetype.version>
     <surefire.version>3.0.0-M8</surefire.version>
     <slf4j.version>2.0.6</slf4j.version>


### PR DESCRIPTION
Indexer uses Version from resolver, and 1.9.5 carries important fixes related to sorting some peculiar versions.

---

https://issues.apache.org/jira/browse/MINDEXER-184