### PR TITLE
[MINDEXER-188] Ensure that the producer thread doesn't indefinitely block on the queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ target/
 *.iml
 .idea/
 
+# NetBeans
+nbactions.xml
+nb-configuration.xml
+
 # Other
 .svn/
 bin/

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,8 @@ under the License.
                 <exclude>.git/**</exclude>
                 <exclude>.idea/**</exclude>
                 <exclude>**/*.iml</exclude>
+                <exclude>nbactions.xml</exclude>
+                <exclude>nb-configuration.xml</exclude>
                 <!-- exlude some test resources from rat analysis -->
                 <exclude>src/test/**/*.sha1</exclude>
                 <exclude>src/test/**/*.md5</exclude>


### PR DESCRIPTION
The consumer Threads can quit early when an exception occurs. In that case the consumer will usually block on `put` once the queue is full without a chance to recover.

This change clears the queue and shuts the executor service down as soon an exception is caught.

fixes: https://issues.apache.org/jira/browse/MINDEXER-188