### PR TITLE
[MINDEXER-190] Avoid using String#split in hot code if possible

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataReader.java
@@ -351,12 +351,15 @@ public class IndexDataReader {
         final Field uinfoField = (Field) doc.getField(ArtifactInfo.UINFO);
         final String info = doc.get(ArtifactInfo.INFO);
         if (uinfoField != null && info != null && !info.isEmpty()) {
-            final String[] splitInfo = ArtifactInfo.FS_PATTERN.split(info);
-            if (splitInfo.length > 6) {
-                final String extension = splitInfo[6];
-                final String uinfoString = uinfoField.stringValue();
-                if (uinfoString.endsWith(ArtifactInfo.FS + ArtifactInfo.NA)) {
-                    uinfoField.setStringValue(uinfoString + ArtifactInfo.FS + ArtifactInfo.nvl(extension));
+            String uinfoString = uinfoField.stringValue();
+            if (uinfoString.endsWith(ArtifactInfo.FS + ArtifactInfo.NA)) {
+                int elem = 0;
+                for (int i = -1; (i = info.indexOf(ArtifactInfo.FS, i + 1)) != -1; ) {
+                    if (++elem == 6) { // extension is field 6
+                        String extension = info.substring(i + 1);
+                        uinfoField.setStringValue(uinfoString + ArtifactInfo.FS + ArtifactInfo.nvl(extension));
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
 - async-profiler showed two optimization opportunities in the index creation code
 - IndexDataReader can avoid some work by moving an if-check up
 - `split` can be replaced by `indexOf` + `substring` pairs
 - this reduces MT extraction time from ~328s to ~303s on my machine (i6700k)

---

https://issues.apache.org/jira/browse/MINDEXER-190

---

![indexer-split](https://github.com/apache/maven-indexer/assets/114367/5ffde316-e4f2-4fb7-8e73-b146697bf946)
![indexer-no-split](https://github.com/apache/maven-indexer/assets/114367/2c17f53f-0d17-4265-af00-f00e641762dc)
