### PR TITLE
[MINDEXER-191] Avoid group rebuilding during incremental updates

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/context/IndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/IndexingContext.java
@@ -244,6 +244,14 @@ public interface IndexingContext {
     void merge(Directory directory, DocumentFilter filter) throws IOException;
 
     /**
+     * Merges content of given Lucene directory with this context, but filters out the unwanted ones and adds the groups to the context.
+     *
+     * @param directory - the directory to merge
+     */
+    void merge(Directory directory, DocumentFilter filter, Set<String> allGroups, Set<String> rootGroups)
+            throws IOException;
+
+    /**
      * Replaces the Lucene index with the one from supplied directory.
      *
      * @param directory

--- a/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/MergedIndexingContext.java
@@ -238,6 +238,11 @@ public class MergedIndexingContext extends AbstractIndexingContext {
         // noop
     }
 
+    public void merge(Directory directory, DocumentFilter filter, Set<String> allGroups, Set<String> rootGroups)
+            throws IOException {
+        // noop
+    }
+
     public void replace(Directory directory) throws IOException {
         // noop
     }

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java
@@ -52,6 +52,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.context.DocumentFilter;
@@ -196,7 +197,7 @@ public class DefaultIndexUpdater implements IndexUpdater {
             }
 
             if (merge) {
-                updateRequest.getIndexingContext().merge(directory);
+                updateRequest.getIndexingContext().merge(directory, null, allGroups, rootGroups);
             } else {
                 updateRequest.getIndexingContext().replace(directory, allGroups, rootGroups);
             }
@@ -227,13 +228,14 @@ public class DefaultIndexUpdater implements IndexUpdater {
             Bits liveDocs = MultiBits.getLiveDocs(r);
 
             int numDocs = r.maxDoc();
+            StoredFields storedFields = r.storedFields();
 
             for (int i = 0; i < numDocs; i++) {
                 if (liveDocs != null && !liveDocs.get(i)) {
                     continue;
                 }
 
-                Document d = r.storedFields().document(i);
+                Document d = storedFields.document(i);
 
                 if (!filter.accept(d)) {
                     boolean success = w.tryDeleteDocument(r, i) != -1;

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DefaultIndexUpdaterTest.java
@@ -42,6 +42,7 @@ import org.apache.maven.index.FlatSearchRequest;
 import org.apache.maven.index.FlatSearchResponse;
 import org.apache.maven.index.MAVEN;
 import org.apache.maven.index.SearchType;
+import org.apache.maven.index.context.DocumentFilter;
 import org.apache.maven.index.context.IndexUtils;
 import org.apache.maven.index.context.IndexingContext;
 import org.jmock.Expectations;
@@ -486,9 +487,19 @@ public class DefaultIndexUpdaterTest extends AbstractIndexUpdaterTest {
                 will(returnValue(newInputStream("index-updater/server-root/nexus-maven-repository-index.gz")));
                 // could create index archive there and verify that it is merged correctly
 
-                oneOf(tempContext).merge(with(any(Directory.class)));
+                oneOf(tempContext)
+                        .merge(
+                                with(any(Directory.class)),
+                                with(aNull(DocumentFilter.class)),
+                                with(any(Set.class)),
+                                with(any(Set.class)));
 
-                oneOf(tempContext).merge(with(any(Directory.class)));
+                oneOf(tempContext)
+                        .merge(
+                                with(any(Directory.class)),
+                                with(aNull(DocumentFilter.class)),
+                                with(any(Set.class)),
+                                with(any(Set.class)));
 
                 oneOf(mockFetcher).disconnect();
             }


### PR DESCRIPTION
Rebuilding of the in-memory group data takes more time than the index update itself since it has to iterate through the full index.

What is worse is that rebuilding happens in a [loop](https://github.com/apache/maven-indexer/blob/fbf7c0c7d305756092ba93e40d77c0a3f0ce7eab/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java#L568-L570) for each chunk:
https://github.com/apache/maven-indexer/blob/fbf7c0c7d305756092ba93e40d77c0a3f0ce7eab/indexer-core/src/main/java/org/apache/maven/index/updater/DefaultIndexUpdater.java#L428-L430

The reader has all group data of the extracted incremental update already, while the context should have the group data of the current index.

If we assume that maven group IDs are rarely removed we can simply merge both collections without having to rebuild anything.

- typical maven central index updates are >4x faster without group rebuilding (<70s on an i6700k)
- minor optimizations and deprecation fixes (additional ~10% faster merge)

context:

https://github.com/apache/maven-indexer/pull/202 moved the groups from index to memory storage which is why NetBeans is persisting the group data after maven-indexer did the extraction https://github.com/apache/netbeans/pull/4136. When the index context is loaded the group data is restored by NB. Incremental updates can simply add more groups to that collection.

Other use cases might want to call `IndexingContext#rebuildGroups()` explicitly, if this isn't done, the context will have only the groups of the incremental update, post update.

---

https://issues.apache.org/jira/browse/MINDEXER-191