### PR TITLE
[MINDEXER-193] Update dependencies

### DIFF
--- a/indexer-examples/indexer-examples-spring/pom.xml
+++ b/indexer-examples/indexer-examples-spring/pom.xml
@@ -33,7 +33,7 @@ under the License.
   <description>This module contains Maven Indexer usage examples for integration with Spring.</description>
 
   <properties>
-    <version.spring>5.3.26</version.spring>
+    <version.spring>5.3.27</version.spring>
   </properties>
 
   <dependencies>
@@ -41,7 +41,7 @@ under the License.
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <version>1.3.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@ under the License.
     <guice.version>5.1.0</guice.version>
     <lucene.version>9.6.0</lucene.version>
     <maven.version>3.9.1</maven.version>
-    <resolver.version>1.9.11</resolver.version>
+    <resolver.version>1.9.10</resolver.version>
     <archetype.version>3.2.1</archetype.version>
     <surefire.version>3.0.0</surefire.version>
     <slf4j.version>2.0.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,11 +102,11 @@ under the License.
     <failsafe.redirectTestOutputToFile>true</failsafe.redirectTestOutputToFile>
     <checkstyle.violation.ignore>MagicNumber,ParameterNumber,MethodLength,JavadocType,AvoidNestedBlocks,InterfaceIsType</checkstyle.violation.ignore>
 
-    <eclipse-sisu.version>0.3.5</eclipse-sisu.version>
+    <eclipse-sisu.version>0.9.0.M2</eclipse-sisu.version>
     <guice.version>5.1.0</guice.version>
     <lucene.version>9.6.0</lucene.version>
     <maven.version>3.9.1</maven.version>
-    <resolver.version>1.9.10</resolver.version>
+    <resolver.version>1.9.11</resolver.version>
     <archetype.version>3.2.1</archetype.version>
     <surefire.version>3.0.0</surefire.version>
     <slf4j.version>2.0.7</slf4j.version>
@@ -266,7 +266,7 @@ under the License.
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>9.4.49.v20220914</version>
+        <version>9.4.51.v20230217</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Changes:
* spring 5.3.27 (demos)
* javax.annotation-api 1.3.2 (demos)
* sisu 0.9.0.M2
* ~resolver 1.9.11~ no need for this
* jetty 9.4.51 (test)

---

https://issues.apache.org/jira/browse/MINDEXER-193