### PR TITLE
[MINDEXER-209] Move off EOLd Jetty, update to 10.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,7 +266,7 @@ under the License.
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>9.4.53.v20231009</version>
+        <version>10.0.18</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Jetty 9.x is EOLd, move to newer version is just bump.

---

https://issues.apache.org/jira/browse/MINDEXER-209