### PR TITLE
[MINDEXER-210][MINDEXER-211] Guava 32.1.3-jre and cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@ under the License.
       </dependency>
 
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>32.1.3-jre</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
         <version>${guice.version}</version>
@@ -237,6 +243,13 @@ under the License.
 
       <dependency>
         <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>2.2</version>
         <scope>test</scope>
@@ -297,6 +310,7 @@ under the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
             <release>${javaVersion}</release>
+            <proc>none</proc>
           </configuration>
         </plugin>
         <plugin>

--- a/search-backend-indexer/pom.xml
+++ b/search-backend-indexer/pom.xml
@@ -68,6 +68,7 @@ under the License.
     <dependency>
       <groupId>org.eclipse.sisu</groupId>
       <artifactId>org.eclipse.sisu.inject</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>


### PR DESCRIPTION
Changes:
* update Guava to 32.1.3-jre
* get rid of Java21+ warning (Sisu APT)
* hamcrest-core 1.3 still lurking somewhere, just up it
* fix scope of Sisu in a module

---

https://issues.apache.org/jira/browse/MINDEXER-210
https://issues.apache.org/jira/browse/MINDEXER-211