### PR TITLE
ArtifactContext should not log warnings if artifacts are no zip files.

### DIFF
--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
@@ -110,7 +110,7 @@ public class ArtifactContext {
                 if (e instanceof ZipException && !isZip) {
                     // ZipFile constructor threw ZipException which means this is no zip file -> ignore
                 } else {
-                    LOGGER.warn("skip error reading pom withing artifact:" + artifact, e);
+                    LOGGER.warn("skip error reading pom within artifact:" + artifact, e);
                 }
             }
         }

--- a/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/ArtifactContext.java
@@ -25,6 +25,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import org.apache.lucene.document.Document;
@@ -92,7 +93,9 @@ public class ArtifactContext {
         }
         // Otherwise, check for pom contained in maven generated artifact
         else if (getArtifact() != null && getArtifact().isFile()) {
+            boolean isZip = false;
             try (ZipFile zipFile = new ZipFile(artifact)) {
+                isZip = true;
                 final String embeddedPomPath =
                         "META-INF/maven/" + getGav().getGroupId() + "/" + getGav().getArtifactId() + "/pom.xml";
 
@@ -104,7 +107,11 @@ public class ArtifactContext {
                     }
                 }
             } catch (IOException | XmlPullParserException e) {
-                LOGGER.warn("skip error reading pom withing artifact:" + artifact, e);
+                if (e instanceof ZipException && !isZip) {
+                    // ZipFile constructor threw ZipException which means this is no zip file -> ignore
+                } else {
+                    LOGGER.warn("skip error reading pom withing artifact:" + artifact, e);
+                }
             }
         }
 


### PR DESCRIPTION
`DefaultScanner` is processing all files which are in the local repo, which means that `ArtifactContext` has to deal with files which are no zip archives too.

This updates `ArtifactContext` to not log zip exceptions as warning if it can't open the zip but should still log all other exceptions which might occur after successful initial read.

for example log see: https://github.com/apache/netbeans/issues/6756 (it uses a different scanner impl but `DefaultScanner` does even less filtering so the result should be the same)