### PR TITLE
Use Jetty Core for test HTTP fixtures

### DIFF
--- a/indexer-cli/pom.xml
+++ b/indexer-cli/pom.xml
@@ -87,11 +87,6 @@ under the License.
       <artifactId>jmock</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -131,12 +131,6 @@ under the License.
       <artifactId>jmock</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -131,6 +131,12 @@ under the License.
       <artifactId>jmock</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
@@ -30,12 +30,8 @@ import java.util.TimeZone;
 
 import org.apache.maven.index.Java11HttpClient;
 import org.apache.maven.index.context.IndexingContext;
+import org.apache.maven.index.updater.fixtures.ServerTestFixture;
 import org.codehaus.plexus.util.FileUtils;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DownloadRemoteIndexerManagerTest extends AbstractIndexUpdaterTest {
-    private Server server;
+    private ServerTestFixture server;
 
     private File fakeCentral;
 
@@ -62,15 +58,7 @@ public class DownloadRemoteIndexerManagerTest extends AbstractIndexUpdaterTest {
         int port = s.getLocalPort();
         s.close();
 
-        server = new Server(port);
-
-        ResourceHandler resource_handler = new ResourceHandler();
-        resource_handler.setResourceBase(fakeCentral.getAbsolutePath());
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] {resource_handler, new DefaultHandler()});
-        server.setHandler(handlers);
-
-        server.start();
+        server = new ServerTestFixture(port, fakeCentral.toPath());
 
         // make context "fake central"
         centralContext = indexer.addIndexingContext(

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
@@ -21,8 +21,6 @@ package org.apache.maven.index.updater.fixtures;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -30,8 +28,14 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.sun.net.httpserver.HttpExchange;
-import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
 
 public class ServerTestFixture {
 
@@ -43,7 +47,7 @@ public class ServerTestFixture {
 
     private final Path base;
 
-    private final HttpServer server;
+    private final Server server;
 
     private final AtomicInteger redirectionCount = new AtomicInteger();
 
@@ -51,12 +55,10 @@ public class ServerTestFixture {
         this(port, getBase());
     }
 
-    public ServerTestFixture(final int port, final Path base) throws IOException {
+    public ServerTestFixture(final int port, final Path base) throws Exception {
         this.base = base.toAbsolutePath().normalize();
-        server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
-        server.createContext("/slow/", this::serveSlowly);
-        server.createContext("/redirect-trap/", this::redirect);
-        server.createContext("/", this::serve);
+        server = new Server(port);
+        server.setHandler(new FixtureHandler());
         server.start();
     }
 
@@ -69,41 +71,41 @@ public class ServerTestFixture {
         return Paths.get(resource.toURI()).normalize();
     }
 
-    public void stop() {
-        server.stop(0);
+    public void stop() throws Exception {
+        server.stop();
+        server.join();
     }
 
-    private void serve(final HttpExchange exchange) throws IOException {
-        if (!requireGet(exchange)) {
-            return;
-        }
-
-        Path file = resolve(exchange.getRequestURI());
+    private boolean serve(final String requestPath, final Response response, final Callback callback)
+            throws IOException {
+        Path file = resolve(requestPath);
         if (file == null || !Files.isRegularFile(file)) {
-            sendEmptyResponse(exchange, 404);
-            return;
+            response.setStatus(HttpStatus.NOT_FOUND_404);
+            callback.succeeded();
+            return true;
         }
 
-        exchange.sendResponseHeaders(200, Files.size(file));
-        try (OutputStream out = exchange.getResponseBody()) {
-            Files.copy(file, out);
-        }
+        response.setStatus(HttpStatus.OK_200);
+        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, Files.size(file));
+        OutputStream out = Content.Sink.asOutputStream(response);
+        Files.copy(file, out);
+        out.flush();
+        callback.succeeded();
+        return true;
     }
 
-    private void serveSlowly(final HttpExchange exchange) throws IOException {
-        if (!requireGet(exchange)) {
-            return;
-        }
-
-        Path file = resolve(exchange.getRequestURI());
+    private boolean serveSlowly(final String requestPath, final Response response, final Callback callback)
+            throws IOException {
+        Path file = resolve(requestPath);
         if (file == null || !Files.isRegularFile(file)) {
-            sendEmptyResponse(exchange, 404);
-            return;
+            response.setStatus(HttpStatus.NOT_FOUND_404);
+            callback.succeeded();
+            return true;
         }
 
-        exchange.sendResponseHeaders(200, 0);
-        try (InputStream in = Files.newInputStream(file);
-                OutputStream out = exchange.getResponseBody()) {
+        response.setStatus(HttpStatus.OK_200);
+        try (InputStream in = Files.newInputStream(file)) {
+            OutputStream out = Content.Sink.asOutputStream(response);
             byte[] buffer = new byte[BUFFER_SIZE];
             int read;
             while ((read = in.read(buffer)) > -1) {
@@ -115,46 +117,31 @@ public class ServerTestFixture {
                 }
                 out.write(buffer, 0, read);
             }
+            out.flush();
         }
+        callback.succeeded();
+        return true;
     }
 
-    private void redirect(final HttpExchange exchange) throws IOException {
-        if (!requireGet(exchange)) {
-            return;
-        }
-
-        URI requestUri = exchange.getRequestURI();
-        String location = requestUri.getRawPath() + "-" + redirectionCount.incrementAndGet();
-        if (requestUri.getRawQuery() != null) {
-            location += "?" + requestUri.getRawQuery();
-        }
-
-        exchange.getResponseHeaders().set("Location", location);
-        sendEmptyResponse(exchange, 302);
-    }
-
-    private Path resolve(final URI requestUri) {
-        String requestPath = requestUri.getPath();
-        if (requestPath == null || !requestPath.startsWith("/")) {
-            return null;
-        }
-
+    private Path resolve(final String requestPath) {
         Path resolved = base.resolve(requestPath.substring(1)).normalize();
         return resolved.startsWith(base) ? resolved : null;
     }
 
-    private static boolean requireGet(final HttpExchange exchange) throws IOException {
-        if ("GET".equals(exchange.getRequestMethod())) {
-            return true;
+    private final class FixtureHandler extends Handler.Abstract {
+        @Override
+        public boolean handle(final Request request, final Response response, final Callback callback)
+                throws Exception {
+            String requestPath = Request.getPathInContext(request);
+            if (requestPath.startsWith("/slow/")) {
+                return serveSlowly(requestPath, response, callback);
+            }
+            if (requestPath.startsWith("/redirect-trap/")) {
+                String location = requestPath + "-" + redirectionCount.incrementAndGet();
+                Response.sendRedirect(request, response, callback, HttpStatus.MOVED_TEMPORARILY_302, location, false);
+                return true;
+            }
+            return serve(requestPath, response, callback);
         }
-
-        exchange.getResponseHeaders().set("Allow", "GET");
-        sendEmptyResponse(exchange, 405);
-        return false;
-    }
-
-    private static void sendEmptyResponse(final HttpExchange exchange, final int status) throws IOException {
-        exchange.sendResponseHeaders(status, -1);
-        exchange.close();
     }
 }

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
@@ -18,158 +18,143 @@
  */
 package org.apache.maven.index.updater.fixtures;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.security.ConstraintMapping;
-import org.eclipse.jetty.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.HashLoginService;
-import org.eclipse.jetty.security.UserStore;
-import org.eclipse.jetty.security.authentication.BasicAuthenticator;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.util.security.Constraint;
-import org.eclipse.jetty.util.security.Password;
-import org.eclipse.jetty.webapp.WebAppContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
 
 public class ServerTestFixture {
 
     private static final String SERVER_ROOT_RESOURCE_PATH = "index-updater/server-root";
 
-    private static final String SIXTY_TWO_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final int BUFFER_SIZE = 64;
 
-    public static final String LONG_PASSWORD = SIXTY_TWO_CHARS + SIXTY_TWO_CHARS;
+    private static final long CHUNK_DELAY_MILLIS = 1000;
 
-    private final Server server;
+    private final Path base;
+
+    private final HttpServer server;
+
+    private final AtomicInteger redirectionCount = new AtomicInteger();
 
     public ServerTestFixture(final int port) throws Exception {
-        server = new Server();
+        this(port, getBase());
+    }
 
-        ServerConnector connector = new ServerConnector(server);
-        connector.setPort(port);
-
-        server.setConnectors(new Connector[] {connector});
-
-        Constraint constraint = new Constraint();
-        constraint.setName(Constraint.__BASIC_AUTH);
-
-        constraint.setRoles(new String[] {"allowed"});
-        constraint.setAuthenticate(true);
-
-        ConstraintMapping cm = new ConstraintMapping();
-        cm.setConstraint(constraint);
-        cm.setPathSpec("/protected/*");
-
-        UserStore userStore = new UserStore();
-        userStore.addUser("user", new Password("password"), new String[] {"allowed"});
-        userStore.addUser("longuser", new Password(LONG_PASSWORD), new String[] {"allowed"});
-        HashLoginService hls = new HashLoginService("POC Server");
-        hls.setUserStore(userStore);
-
-        ConstraintSecurityHandler sh = new ConstraintSecurityHandler();
-        sh.setAuthenticator(new BasicAuthenticator());
-        sh.setLoginService(hls);
-        sh.setConstraintMappings(new ConstraintMapping[] {cm});
-
-        WebAppContext ctx = new WebAppContext();
-        ctx.setContextPath("/");
-
-        File base = getBase();
-        ctx.setWar(base.getAbsolutePath());
-        ctx.setSecurityHandler(sh);
-
-        ctx.getServletHandler().addServletWithMapping(TimingServlet.class, "/slow/*");
-        ctx.getServletHandler().addServletWithMapping(InfiniteRedirectionServlet.class, "/redirect-trap/*");
-
-        SessionHandler sessionHandler = ctx.getSessionHandler();
-        sessionHandler.setUsingCookies(true);
-
-        HandlerCollection handlers = new HandlerCollection();
-        handlers.setHandlers(new Handler[] {ctx, new DefaultHandler()});
-
-        server.setHandler(handlers);
+    public ServerTestFixture(final int port, final Path base) throws IOException {
+        this.base = base.toAbsolutePath().normalize();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+        server.createContext("/slow/", this::serveSlowly);
+        server.createContext("/redirect-trap/", this::redirect);
+        server.createContext("/", this::serve);
         server.start();
     }
 
-    private static File getBase() throws URISyntaxException {
+    private static Path getBase() throws URISyntaxException {
         URL resource = Thread.currentThread().getContextClassLoader().getResource(SERVER_ROOT_RESOURCE_PATH);
         if (resource == null) {
             throw new IllegalStateException("Cannot find classpath resource: " + SERVER_ROOT_RESOURCE_PATH);
         }
 
-        return new File(resource.toURI().normalize());
+        return Paths.get(resource.toURI()).normalize();
     }
 
-    public void stop() throws Exception {
-        server.stop();
-        server.join();
+    public void stop() {
+        server.stop(0);
     }
 
-    public static final class TimingServlet extends HttpServlet {
-        private static final long serialVersionUID = 1L;
+    private void serve(final HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange)) {
+            return;
+        }
 
-        @Override
-        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
-            String basePath = req.getServletPath();
-            String subPath = req.getRequestURI().substring(basePath.length());
+        Path file = resolve(exchange.getRequestURI());
+        if (file == null || !Files.isRegularFile(file)) {
+            sendEmptyResponse(exchange, 404);
+            return;
+        }
 
-            File base;
-            try {
-                base = getBase();
-            } catch (URISyntaxException e) {
-                resp.sendError(
-                        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                        "Cannot find server document root in classpath: " + SERVER_ROOT_RESOURCE_PATH);
-                return;
-            }
+        exchange.sendResponseHeaders(200, Files.size(file));
+        try (OutputStream out = exchange.getResponseBody()) {
+            Files.copy(file, out);
+        }
+    }
 
-            File f = new File(base, "slow" + subPath);
-            try (InputStream in = new FileInputStream(f)) {
-                OutputStream out = resp.getOutputStream();
+    private void serveSlowly(final HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange)) {
+            return;
+        }
 
-                int read;
-                byte[] buf = new byte[64];
-                while ((read = in.read(buf)) > -1) {
-                    System.out.println("Sending " + read + " bytes (after pausing 1 seconds)...");
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
+        Path file = resolve(exchange.getRequestURI());
+        if (file == null || !Files.isRegularFile(file)) {
+            sendEmptyResponse(exchange, 404);
+            return;
+        }
 
-                    out.write(buf, 0, read);
+        exchange.sendResponseHeaders(200, 0);
+        try (InputStream in = Files.newInputStream(file);
+                OutputStream out = exchange.getResponseBody()) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = in.read(buffer)) > -1) {
+                try {
+                    Thread.sleep(CHUNK_DELAY_MILLIS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while serving a slow response", e);
                 }
-
-                out.flush();
+                out.write(buffer, 0, read);
             }
         }
     }
 
-    public static final class InfiniteRedirectionServlet extends HttpServlet {
-        private static final long serialVersionUID = 1L;
-
-        static int redirCount = 0;
-
-        @Override
-        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
-            String path = req.getServletPath();
-            String subPath = req.getRequestURI().substring(path.length());
-
-            path += subPath + "-" + (++redirCount);
-            resp.sendRedirect(path);
+    private void redirect(final HttpExchange exchange) throws IOException {
+        if (!requireGet(exchange)) {
+            return;
         }
+
+        URI requestUri = exchange.getRequestURI();
+        String location = requestUri.getRawPath() + "-" + redirectionCount.incrementAndGet();
+        if (requestUri.getRawQuery() != null) {
+            location += "?" + requestUri.getRawQuery();
+        }
+
+        exchange.getResponseHeaders().set("Location", location);
+        sendEmptyResponse(exchange, 302);
+    }
+
+    private Path resolve(final URI requestUri) {
+        String requestPath = requestUri.getPath();
+        if (requestPath == null || !requestPath.startsWith("/")) {
+            return null;
+        }
+
+        Path resolved = base.resolve(requestPath.substring(1)).normalize();
+        return resolved.startsWith(base) ? resolved : null;
+    }
+
+    private static boolean requireGet(final HttpExchange exchange) throws IOException {
+        if ("GET".equals(exchange.getRequestMethod())) {
+            return true;
+        }
+
+        exchange.getResponseHeaders().set("Allow", "GET");
+        sendEmptyResponse(exchange, 405);
+        return false;
+    }
+
+    private static void sendEmptyResponse(final HttpExchange exchange, final int status) throws IOException {
+        exchange.sendResponseHeaders(status, -1);
+        exchange.close();
     }
 }

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
@@ -18,10 +18,6 @@
  */
 package org.apache.maven.index.updater.fixtures;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,6 +26,9 @@ import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,13 @@ under the License.
       </dependency>
 
       <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>12.1.12</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.jmock</groupId>
         <artifactId>jmock</artifactId>
         <version>2.13.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@ under the License.
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>10.0.24</version>
+        <version>11.0.25</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -283,13 +283,6 @@ under the License.
           </exclusion>
         </exclusions>
       </dependency>
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
-        <version>11.0.25</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This addresses [the maintainer's review](https://github.com/apache/maven-indexer/pull/764#issuecomment-5439047001) by using Jetty Core directly, without a Servlet API. It supersedes the `jetty-webapp` upgrade in #762.

## What changed

- replace the `WebAppContext`/Servlet fixture with Jetty 12's Core `Handler` API;
- preserve fresh static-file reads on every request, delayed chunked responses, and the explicit 302 redirect loop;
- reuse the fixture in `DownloadRemoteIndexerManagerTest` instead of maintaining a second Jetty server;
- remove the obsolete authentication fixture whose consumers were removed in #252;
- replace `jetty-webapp` with test-scoped `jetty-server` in `indexer-core`, and remove the unused Jetty dependency from `indexer-cli`.

The resulting test graph contains only Jetty Core's `server`, `http`, `io`, and `util` artifacts in `indexer-core`; `indexer-cli` has no Jetty dependency, and neither module has a Servlet API. Version 12.1.12 and this Core handler style match the current Apache Maven integration-test fixture.

## Verification

Maven 3.9.16 was used throughout.

- final candidate `00c0a07d5dd3e86f9e467a8b64609a31a2b5c3ff`, JDK 17: `mvn --errors --batch-mode --show-version -Dinvoker.streamLogsOnFailures -P run-its clean verify` — all 11 reactor modules passed;
- final candidate, JDK 21 on a clean JAIPilot remote workspace: `mvn --errors --batch-mode --show-version -pl indexer-core clean verify` — 225 unit tests and 5 integration tests passed;
- focused JDK 17 verification: `mvn --batch-mode --show-version -pl indexer-core -Dtest=DownloadRemoteIndexerManagerTest -Dit.test=DefaultIndexUpdaterEmbeddingIT verify` — 2 unit tests and 5 integration tests passed;
- dependency-tree verification for `indexer-core` and `indexer-cli` confirms no Servlet artifacts and no Jetty dependency in the CLI;
- RAT, Checkstyle, Spotless, bytecode enforcement, Surefire, and Failsafe passed; `git diff --check` is clean.

The repository currently reports that the requested `run-its` profile does not exist; its core integration tests are lifecycle-bound and ran successfully.

## Checklist

- [x] The change is limited to test fixtures and their dependencies.
- [x] The mutable repository, slow-response, and redirect behavior is exercised by existing tests.
- [x] The complete reactor passes from clean outputs.
- [x] The follow-up commit is signed off.
- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](https://www.apache.org/licenses/LICENSE-2.0).
