### PR TITLE
Update lucene from 9.12.3 to 10.5.1

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -27,7 +27,7 @@ jobs:
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v5
     with:
       ff-run: false
-      jdk-matrix: '[ "17", "21" ]'
+      jdk-matrix: '[ "21", "25" ]'
       maven-matrix: '[ "3.9.9" ]'
 
 

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIndexerEngine.java
@@ -140,8 +140,8 @@ public class DefaultIndexerEngine implements IndexerEngine {
                                 ArtifactInfo.UINFO, ac.getArtifactInfo().getUinfo())),
                         2);
 
-                if (result.totalHits.value == 1) {
-                    return indexSearcher.doc(result.scoreDocs[0].doc);
+                if (result.totalHits.value() == 1) {
+                    return indexSearcher.storedFields().document(result.scoreDocs[0].doc);
                 }
             } finally {
                 context.releaseIndexSearcher(indexSearcher);

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultIteratorResultSet.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultIteratorResultSet.java
@@ -28,6 +28,7 @@ import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CachingTokenFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -109,9 +110,10 @@ public class DefaultIteratorResultSet implements IteratorResultSet {
 
         this.matchHighlightRequests = request.getMatchHighlightRequests();
 
+        // TODO list never read?
         List<MatchHighlightRequest> matchHighlightRequests = new ArrayList<>();
         for (MatchHighlightRequest hr : request.getMatchHighlightRequests()) {
-            Query rewrittenQuery = hr.getQuery().rewrite(indexSearcher.getIndexReader());
+            Query rewrittenQuery = hr.getQuery().rewrite(indexSearcher);
             matchHighlightRequests.add(new MatchHighlightRequest(hr.getField(), rewrittenQuery, hr.getHighlightMode()));
         }
 
@@ -192,13 +194,14 @@ public class DefaultIteratorResultSet implements IteratorResultSet {
     protected ArtifactInfo createNextAi() throws IOException {
         ArtifactInfo result = null;
 
+        StoredFields storedFields = indexSearcher.storedFields();
         // we should stop if:
         // a) we found what we want
         // b) pointer advanced over more documents that user requested
         // c) pointer advanced over more documents that hits has
         // or we found what we need
         while ((result == null) && (pointer < maxRecPointer) && (pointer < hits.scoreDocs.length)) {
-            Document doc = indexSearcher.doc(hits.scoreDocs[pointer].doc);
+            Document doc = storedFields.document(hits.scoreDocs[pointer].doc);
 
             IndexingContext context = getIndexingContextForPointer(doc, hits.scoreDocs[pointer].doc);
 

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultScannerListener.java
@@ -28,10 +28,12 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.context.IndexingContext;
 
@@ -178,10 +180,11 @@ public class DefaultScannerListener implements ArtifactScanningListener {
         try {
             final IndexReader r = indexSearcher.getIndexReader();
             Bits liveDocs = MultiBits.getLiveDocs(r);
+            StoredFields storedFields = r.storedFields();
 
             for (int i = 0; i < r.maxDoc(); i++) {
                 if (liveDocs == null || liveDocs.get(i)) {
-                    Document d = r.document(i);
+                    Document d = storedFields.document(i);
 
                     String uinfo = d.get(ArtifactInfo.UINFO);
 
@@ -217,11 +220,11 @@ public class DefaultScannerListener implements ArtifactScanningListener {
         final IndexSearcher indexSearcher = context.acquireIndexSearcher();
         try {
             for (String uinfo : uinfos) {
-                TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+                TopScoreDocCollectorManager collector = new TopScoreDocCollectorManager(1, Integer.MAX_VALUE);
 
-                indexSearcher.search(new TermQuery(new Term(ArtifactInfo.UINFO, uinfo)), collector);
+                TopDocs topdocs = indexSearcher.search(new TermQuery(new Term(ArtifactInfo.UINFO, uinfo)), collector);
 
-                if (collector.getTotalHits() > 0) {
+                if (topdocs.totalHits.value() > 0) {
                     String[] ra = ArtifactInfo.FS_PATTERN.split(uinfo);
 
                     ArtifactInfo ai = new ArtifactInfo();
@@ -245,7 +248,7 @@ public class DefaultScannerListener implements ArtifactScanningListener {
                     // minimal ArtifactContext for removal
                     ArtifactContext ac = new ArtifactContext(null, null, null, ai, ai.calculateGav());
 
-                    for (int i = 0; i < collector.getTotalHits(); i++) {
+                    for (int i = 0; i < topdocs.totalHits.value(); i++) {
                         if (contextPath == null
                                 || context.getGavCalculator()
                                         .gavToPath(ac.getGav())

--- a/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/DefaultSearchEngine.java
@@ -33,10 +33,12 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
 import org.apache.maven.index.context.IndexUtils;
 import org.apache.maven.index.context.IndexingContext;
 import org.apache.maven.index.context.NexusIndexMultiReader;
@@ -96,7 +98,9 @@ public class DefaultSearchEngine implements SearchEngine {
 
         final TreeSet<ArtifactInfo> result = new TreeSet<>(request.getArtifactInfoComparator());
         return new FlatSearchResponse(
-                request.getQuery(), searchFlat(request, result, contexts, request.getQuery()), result);
+                request.getQuery(),
+                (int) searchFlat(request, result, contexts, request.getQuery()), // TODO long downcast
+                result);
     }
 
     // ==
@@ -120,40 +124,42 @@ public class DefaultSearchEngine implements SearchEngine {
 
         return new GroupedSearchResponse(
                 request.getQuery(),
-                searchGrouped(request, result, request.getGrouping(), contexts, request.getQuery()),
+                (int) searchGrouped(
+                        request, result, request.getGrouping(), contexts, request.getQuery()), // TODO long downcast
                 result);
     }
 
     // ===
 
-    protected int searchFlat(
+    protected long searchFlat(
             FlatSearchRequest req,
             Collection<ArtifactInfo> result,
             List<IndexingContext> participatingContexts,
             Query query)
             throws IOException {
-        int hitCount = 0;
+        long hitCount = 0;
         for (IndexingContext context : participatingContexts) {
             final IndexSearcher indexSearcher = context.acquireIndexSearcher();
+            final StoredFields storedFields = indexSearcher.storedFields();
             try {
-                final TopScoreDocCollector collector = doSearchWithCeiling(req, indexSearcher, query);
+                final TopDocs topdocs = doSearchWithCeiling(req, indexSearcher, query);
 
-                if (collector.getTotalHits() == 0) {
+                if (topdocs.totalHits.value() == 0) {
                     // context has no hits, just continue to next one
                     continue;
                 }
 
-                ScoreDoc[] scoreDocs = collector.topDocs().scoreDocs;
+                ScoreDoc[] scoreDocs = topdocs.scoreDocs;
 
                 // uhm btw hitCount contains dups
 
-                hitCount += collector.getTotalHits();
+                hitCount += topdocs.totalHits.value();
 
                 int start = 0; // from == FlatSearchRequest.UNDEFINED ? 0 : from;
 
                 // we have to pack the results as long: a) we have found aiCount ones b) we depleted hits
                 for (int i = start; i < scoreDocs.length; i++) {
-                    Document doc = indexSearcher.doc(scoreDocs[i].doc);
+                    Document doc = storedFields.document(scoreDocs[i].doc);
 
                     ArtifactInfo artifactInfo = IndexUtils.constructArtifactInfo(doc, context);
 
@@ -181,27 +187,28 @@ public class DefaultSearchEngine implements SearchEngine {
         return hitCount;
     }
 
-    protected int searchGrouped(
+    protected long searchGrouped(
             GroupedSearchRequest req,
             Map<String, ArtifactInfoGroup> result,
             Grouping grouping,
             List<IndexingContext> participatingContexts,
             Query query)
             throws IOException {
-        int hitCount = 0;
+        long hitCount = 0;
 
         for (IndexingContext context : participatingContexts) {
             final IndexSearcher indexSearcher = context.acquireIndexSearcher();
+            final StoredFields storedFields = indexSearcher.storedFields();
             try {
-                final TopScoreDocCollector collector = doSearchWithCeiling(req, indexSearcher, query);
+                final TopDocs topdocs = doSearchWithCeiling(req, indexSearcher, query);
 
-                if (collector.getTotalHits() > 0) {
-                    ScoreDoc[] scoreDocs = collector.topDocs().scoreDocs;
+                if (topdocs.totalHits.value() > 0) {
+                    ScoreDoc[] scoreDocs = topdocs.scoreDocs;
 
-                    hitCount += collector.getTotalHits();
+                    hitCount += topdocs.totalHits.value();
 
                     for (ScoreDoc scoreDoc : scoreDocs) {
-                        Document doc = indexSearcher.doc(scoreDoc.doc);
+                        Document doc = storedFields.document(scoreDoc.doc);
 
                         ArtifactInfo artifactInfo = IndexUtils.constructArtifactInfo(doc, context);
 
@@ -255,12 +262,12 @@ public class DefaultSearchEngine implements SearchEngine {
         NexusIndexMultiSearcher indexSearcher = new NexusIndexMultiSearcher(multiReader);
 
         try {
-            TopScoreDocCollector hits = doSearchWithCeiling(request, indexSearcher, request.getQuery());
+            TopDocs topdocs = doSearchWithCeiling(request, indexSearcher, request.getQuery());
 
             return new IteratorSearchResponse(
                     request.getQuery(),
-                    hits.getTotalHits(),
-                    new DefaultIteratorResultSet(request, indexSearcher, contexts, hits.topDocs()));
+                    (int) topdocs.totalHits.value(), // TODO long downcast
+                    new DefaultIteratorResultSet(request, indexSearcher, contexts, topdocs));
         } catch (IOException | RuntimeException e) {
             try {
                 indexSearcher.release();
@@ -273,29 +280,27 @@ public class DefaultSearchEngine implements SearchEngine {
 
     // ==
 
-    protected TopScoreDocCollector doSearchWithCeiling(
+    protected TopDocs doSearchWithCeiling(
             final AbstractSearchRequest request, final IndexSearcher indexSearcher, final Query query)
             throws IOException {
         int topHitCount = getTopDocsCollectorHitNum(request, AbstractSearchRequest.UNDEFINED);
 
         if (AbstractSearchRequest.UNDEFINED != topHitCount) {
             // count is set, simply just execute it as-is
-            final TopScoreDocCollector hits = TopScoreDocCollector.create(topHitCount, Integer.MAX_VALUE);
+            final TopScoreDocCollectorManager hits = new TopScoreDocCollectorManager(topHitCount, Integer.MAX_VALUE);
 
-            indexSearcher.search(query, hits);
-
-            return hits;
+            return indexSearcher.search(query, hits);
         } else {
             // set something reasonable as 1k
             topHitCount = 1000;
 
             // perform search
-            TopScoreDocCollector hits = TopScoreDocCollector.create(topHitCount, Integer.MAX_VALUE);
-            indexSearcher.search(query, hits);
+            TopScoreDocCollectorManager hits = new TopScoreDocCollectorManager(topHitCount, Integer.MAX_VALUE);
+            TopDocs result = indexSearcher.search(query, hits);
 
             // check total hits against, does it fit?
-            if (topHitCount < hits.getTotalHits()) {
-                topHitCount = hits.getTotalHits();
+            if (topHitCount < result.totalHits.value()) {
+                topHitCount = (int) result.totalHits.value();
 
                 if (getLogger().isDebugEnabled()) {
                     // warn the user and leave trace just before OOM might happen
@@ -307,11 +312,11 @@ public class DefaultSearchEngine implements SearchEngine {
                 }
 
                 // redo all, but this time with correct numbers
-                hits = TopScoreDocCollector.create(topHitCount, Integer.MAX_VALUE);
-                indexSearcher.search(query, hits);
+                hits = new TopScoreDocCollectorManager(topHitCount, Integer.MAX_VALUE);
+                result = indexSearcher.search(query, hits);
             }
 
-            return hits;
+            return result;
         }
     }
 

--- a/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/context/DefaultIndexingContext.java
@@ -49,7 +49,8 @@ import org.apache.lucene.index.Term;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TopScoreDocCollector;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.search.TopScoreDocCollectorManager;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.store.FSLockFactory;
@@ -322,21 +323,21 @@ public class DefaultIndexingContext extends AbstractIndexingContext {
 
         // check for descriptor if this is not a "virgin" index
         if (getSize() > 0) {
-            final TopScoreDocCollector collector = TopScoreDocCollector.create(1, Integer.MAX_VALUE);
+            final TopScoreDocCollectorManager collector = new TopScoreDocCollectorManager(1, Integer.MAX_VALUE);
             final IndexSearcher indexSearcher = acquireIndexSearcher();
             try {
-                indexSearcher.search(new TermQuery(DESCRIPTOR_TERM), collector);
+                TopDocs result = indexSearcher.search(new TermQuery(DESCRIPTOR_TERM), collector);
 
-                if (collector.getTotalHits() == 0) {
+                if (result.totalHits.value() == 0) {
                     throw new ExistingLuceneIndexMismatchException("The existing index has no NexusIndexer descriptor");
                 }
 
-                if (collector.getTotalHits() > 1) {
+                if (result.totalHits.value() > 1) {
                     // eh? this is buggy index it seems, just iron it out then
                     storeDescriptor();
                 } else {
                     // good, we have one descriptor as should
-                    Document descriptor = indexSearcher.storedFields().document(collector.topDocs().scoreDocs[0].doc);
+                    Document descriptor = indexSearcher.storedFields().document(result.scoreDocs[0].doc);
                     String[] h = StringUtils.split(descriptor.get(FLD_IDXINFO), ArtifactInfo.FS);
                     // String version = h[0];
                     String repoId = h[1];
@@ -614,9 +615,9 @@ public class DefaultIndexingContext extends AbstractIndexingContext {
 
                     String uinfo = d.get(ArtifactInfo.UINFO);
                     if (uinfo != null) {
-                        TopScoreDocCollector collector = TopScoreDocCollector.create(1, 1);
-                        s.search(new TermQuery(new Term(ArtifactInfo.UINFO, uinfo)), collector);
-                        if (collector.getTotalHits() == 0) {
+                        TopScoreDocCollectorManager collector = new TopScoreDocCollectorManager(1, 1);
+                        TopDocs result = s.search(new TermQuery(new Term(ArtifactInfo.UINFO, uinfo)), collector);
+                        if (result.totalHits.value() == 0) {
                             w.addDocument(IndexUtils.updateDocument(d, this, false));
                         }
                     } else {

--- a/indexer-core/src/main/java/org/apache/maven/index/incremental/DefaultIncrementalHandler.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/incremental/DefaultIncrementalHandler.java
@@ -39,6 +39,7 @@ import java.util.TreeMap;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.context.IndexingContext;
@@ -135,10 +136,11 @@ public class DefaultIncrementalHandler implements IncrementalHandler {
     private List<Integer> getIndexChunk(IndexPackingRequest request, Date timestamp) throws IOException {
         final List<Integer> chunk = new ArrayList<>();
         final IndexReader r = request.getIndexReader();
+        final StoredFields storedFields = r.storedFields();
         Bits liveDocs = MultiBits.getLiveDocs(r);
         for (int i = 0; i < r.maxDoc(); i++) {
             if (liveDocs == null || liveDocs.get(i)) {
-                Document d = r.document(i);
+                Document d = storedFields.document(i);
 
                 String lastModified = d.get(ArtifactInfo.LAST_MODIFIED);
 

--- a/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
+++ b/indexer-core/src/main/java/org/apache/maven/index/updater/IndexDataWriter.java
@@ -35,6 +35,7 @@ import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.ArtifactInfo;
 import org.apache.maven.index.IndexerField;
@@ -128,11 +129,11 @@ public class IndexDataWriter {
     public int writeDocuments(IndexReader r, List<Integer> docIndexes) throws IOException {
         int n = 0;
         Bits liveDocs = MultiBits.getLiveDocs(r);
-
+        StoredFields storedFields = r.storedFields();
         if (docIndexes == null) {
             for (int i = 0; i < r.maxDoc(); i++) {
                 if (liveDocs == null || liveDocs.get(i)) {
-                    if (writeDocument(r.document(i))) {
+                    if (writeDocument(storedFields.document(i))) {
                         n++;
                     }
                 }
@@ -140,7 +141,7 @@ public class IndexDataWriter {
         } else {
             for (int i : docIndexes) {
                 if (liveDocs == null || liveDocs.get(i)) {
-                    if (writeDocument(r.document(i))) {
+                    if (writeDocument(storedFields.document(i))) {
                         n++;
                     }
                 }

--- a/indexer-core/src/test/java/org/apache/maven/index/AbstractRepoNexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/AbstractRepoNexusIndexerTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.Bits;
 import org.apache.maven.index.search.grouping.GAGrouping;
@@ -501,11 +502,11 @@ public abstract class AbstractRepoNexusIndexerTest extends AbstractNexusIndexerT
     @Test
     public void testPackaging() throws Exception {
         IndexReader reader = context.acquireIndexSearcher().getIndexReader();
-
+        StoredFields storedFields = reader.storedFields();
         Bits liveDocs = MultiBits.getLiveDocs(reader);
         for (int i = 0; i < reader.maxDoc(); i++) {
             if (liveDocs == null || liveDocs.get(i)) {
-                Document document = reader.document(i);
+                Document document = storedFields.document(i);
 
                 String uinfo = document.get(ArtifactInfo.UINFO);
 

--- a/indexer-core/src/test/java/org/apache/maven/index/Nexus737NexusIndexerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/Nexus737NexusIndexerTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiBits;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.util.Bits;
 import org.junit.jupiter.api.Test;
 
@@ -43,12 +44,12 @@ public class Nexus737NexusIndexerTest extends AbstractNexusIndexerTest {
     public void testValidateUINFOs() throws Exception {
         IndexReader reader = context.acquireIndexSearcher().getIndexReader();
         Bits liveDocs = MultiBits.getLiveDocs(reader);
-
+        StoredFields storedFields = reader.storedFields();
         int foundCount = 0;
 
         for (int i = 0; i < reader.maxDoc(); i++) {
             if (liveDocs == null || liveDocs.get(i)) {
-                Document document = reader.document(i);
+                Document document = storedFields.document(i);
 
                 String uinfo = document.get(ArtifactInfo.UINFO);
 

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/IndexDataTest.java
@@ -30,6 +30,7 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
@@ -142,9 +143,9 @@ public class IndexDataTest extends AbstractRepoNexusIndexerTest {
 
     private Map<String, ArtifactInfo> readIndex(IndexReader r1) throws CorruptIndexException, IOException {
         Map<String, ArtifactInfo> map = new HashMap<>();
-
+        StoredFields storedFields = r1.storedFields();
         for (int i = 0; i < r1.maxDoc(); i++) {
-            Document document = r1.document(i);
+            Document document = storedFields.document(i);
 
             ArtifactInfo ai = IndexUtils.constructArtifactInfo(document, context);
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,13 +95,13 @@ under the License.
   <properties>
     <checkstyle.includeTestSourceDirectory>false</checkstyle.includeTestSourceDirectory>
 
-    <javaVersion>11</javaVersion>
+    <javaVersion>21</javaVersion>
     <!-- Remove these two below when MPOM-449 fixed -->
     <maven.compiler.source>${javaVersion}</maven.compiler.source>
     <maven.compiler.target>${javaVersion}</maven.compiler.target>
     <maven.compiler.release>${javaVersion}</maven.compiler.release>
     <minimalMavenBuildVersion>[3.9,)</minimalMavenBuildVersion>
-    <minimalJavaBuildVersion>[17,)</minimalJavaBuildVersion>
+    <minimalJavaBuildVersion>[21,)</minimalJavaBuildVersion>
 
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
     <failsafe.redirectTestOutputToFile>true</failsafe.redirectTestOutputToFile>
@@ -109,7 +109,7 @@ under the License.
 
     <eclipse-sisu.version>1.1.0</eclipse-sisu.version>
     <guice.version>6.0.0</guice.version>
-    <lucene.version>9.12.3</lucene.version>
+    <lucene.version>10.5.1</lucene.version>
     <maven.version>3.9.16</maven.version>
     <resolver.version>2.0.22</resolver.version>
     <archetype.version>3.4.1</archetype.version>
@@ -228,7 +228,7 @@ under the License.
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
-        <version>3.6.1</version>
+        <version>3.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven</groupId>
@@ -287,7 +287,7 @@ under the License.
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-webapp</artifactId>
-        <version>10.0.24</version>
+        <version>10.0.26</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
only minor changes were needed. There is no hurry to get this in, but I have done something similar for the NetBeans code indexer (https://github.com/apache/netbeans/pull/9593), so I thought to open a PR for the maven-indexer too.

 - lower bound becomes JDK 21
 - migrated lucene usage

https://lucene.apache.org/core/10_5_1/changes/Changes.html

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
