### PR TITLE
MINDEXER-760 Replace Jetty test server

### DIFF
--- a/indexer-cli/pom.xml
+++ b/indexer-cli/pom.xml
@@ -87,11 +87,6 @@ under the License.
       <artifactId>jmock</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/indexer-core/pom.xml
+++ b/indexer-core/pom.xml
@@ -132,11 +132,6 @@ under the License.
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/DownloadRemoteIndexerManagerTest.java
@@ -30,12 +30,8 @@ import java.util.TimeZone;
 
 import org.apache.maven.index.Java11HttpClient;
 import org.apache.maven.index.context.IndexingContext;
+import org.apache.maven.index.updater.fixtures.HttpServerFixture;
 import org.codehaus.plexus.util.FileUtils;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerList;
-import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +39,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DownloadRemoteIndexerManagerTest extends AbstractIndexUpdaterTest {
-    private Server server;
+    private HttpServerFixture server;
 
     private File fakeCentral;
 
@@ -62,14 +58,7 @@ public class DownloadRemoteIndexerManagerTest extends AbstractIndexUpdaterTest {
         int port = s.getLocalPort();
         s.close();
 
-        server = new Server(port);
-
-        ResourceHandler resource_handler = new ResourceHandler();
-        resource_handler.setResourceBase(fakeCentral.getAbsolutePath());
-        HandlerList handlers = new HandlerList();
-        handlers.setHandlers(new Handler[] {resource_handler, new DefaultHandler()});
-        server.setHandler(handlers);
-
+        server = new HttpServerFixture(port, fakeCentral);
         server.start();
 
         // make context "fake central"

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/HttpServerFixture.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/HttpServerFixture.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.index.updater.fixtures;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.sun.net.httpserver.BasicAuthenticator;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+public class HttpServerFixture {
+
+    private static final int BUFFER_SIZE = 64;
+
+    private final Path root;
+
+    private final HttpServer server;
+
+    private final AtomicInteger redirects = new AtomicInteger();
+
+    public HttpServerFixture(final int port, final File root) throws IOException {
+        this.root = root.toPath().toRealPath();
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", port), 0);
+        server.createContext("/", this::serveFile);
+    }
+
+    public void addBasicAuthentication(final String path, final String realm, final Map<String, String> credentials) {
+        server.createContext(path, this::serveFile).setAuthenticator(new BasicAuthenticator(realm) {
+            @Override
+            public boolean checkCredentials(final String username, final String password) {
+                return password.equals(credentials.get(username));
+            }
+        });
+    }
+
+    public void addRedirectTrap(final String path) {
+        server.createContext(path, exchange -> {
+            exchange.getResponseHeaders()
+                    .set("Location", exchange.getRequestURI().getPath() + "-" + redirects.incrementAndGet());
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+    }
+
+    public void addSlowResponse(final String path) {
+        server.createContext(path, exchange -> serveFile(exchange, true));
+    }
+
+    public void start() {
+        server.start();
+    }
+
+    public void stop() {
+        server.stop(0);
+    }
+
+    private void serveFile(final HttpExchange exchange) throws IOException {
+        serveFile(exchange, false);
+    }
+
+    private void serveFile(final HttpExchange exchange, final boolean slow) throws IOException {
+        if (!"GET".equals(exchange.getRequestMethod())) {
+            exchange.getResponseHeaders().set("Allow", "GET");
+            exchange.sendResponseHeaders(405, -1);
+            exchange.close();
+            return;
+        }
+
+        Path file =
+                root.resolve(exchange.getRequestURI().getPath().substring(1)).normalize();
+        if (!file.startsWith(root) || !Files.isRegularFile(file)) {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+            return;
+        }
+
+        exchange.sendResponseHeaders(200, Files.size(file));
+        try (InputStream in = Files.newInputStream(file);
+                OutputStream out = exchange.getResponseBody()) {
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                if (slow) {
+                    pause();
+                }
+                out.write(buffer, 0, read);
+                out.flush();
+            }
+        }
+    }
+
+    private static void pause() throws IOException {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while sending a delayed response", e);
+        }
+    }
+}

--- a/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
+++ b/indexer-core/src/test/java/org/apache/maven/index/updater/fixtures/ServerTestFixture.java
@@ -18,33 +18,10 @@
  */
 package org.apache.maven.index.updater.fixtures;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
-
-import org.eclipse.jetty.security.ConstraintMapping;
-import org.eclipse.jetty.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.HashLoginService;
-import org.eclipse.jetty.security.UserStore;
-import org.eclipse.jetty.security.authentication.BasicAuthenticator;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
-import org.eclipse.jetty.server.handler.HandlerCollection;
-import org.eclipse.jetty.server.session.SessionHandler;
-import org.eclipse.jetty.util.security.Constraint;
-import org.eclipse.jetty.util.security.Password;
-import org.eclipse.jetty.webapp.WebAppContext;
+import java.util.Map;
 
 public class ServerTestFixture {
 
@@ -54,54 +31,14 @@ public class ServerTestFixture {
 
     public static final String LONG_PASSWORD = SIXTY_TWO_CHARS + SIXTY_TWO_CHARS;
 
-    private final Server server;
+    private final HttpServerFixture server;
 
     public ServerTestFixture(final int port) throws Exception {
-        server = new Server();
-
-        ServerConnector connector = new ServerConnector(server);
-        connector.setPort(port);
-
-        server.setConnectors(new Connector[] {connector});
-
-        Constraint constraint = new Constraint();
-        constraint.setName(Constraint.__BASIC_AUTH);
-
-        constraint.setRoles(new String[] {"allowed"});
-        constraint.setAuthenticate(true);
-
-        ConstraintMapping cm = new ConstraintMapping();
-        cm.setConstraint(constraint);
-        cm.setPathSpec("/protected/*");
-
-        UserStore userStore = new UserStore();
-        userStore.addUser("user", new Password("password"), new String[] {"allowed"});
-        userStore.addUser("longuser", new Password(LONG_PASSWORD), new String[] {"allowed"});
-        HashLoginService hls = new HashLoginService("POC Server");
-        hls.setUserStore(userStore);
-
-        ConstraintSecurityHandler sh = new ConstraintSecurityHandler();
-        sh.setAuthenticator(new BasicAuthenticator());
-        sh.setLoginService(hls);
-        sh.setConstraintMappings(new ConstraintMapping[] {cm});
-
-        WebAppContext ctx = new WebAppContext();
-        ctx.setContextPath("/");
-
-        File base = getBase();
-        ctx.setWar(base.getAbsolutePath());
-        ctx.setSecurityHandler(sh);
-
-        ctx.getServletHandler().addServletWithMapping(TimingServlet.class, "/slow/*");
-        ctx.getServletHandler().addServletWithMapping(InfiniteRedirectionServlet.class, "/redirect-trap/*");
-
-        SessionHandler sessionHandler = ctx.getSessionHandler();
-        sessionHandler.setUsingCookies(true);
-
-        HandlerCollection handlers = new HandlerCollection();
-        handlers.setHandlers(new Handler[] {ctx, new DefaultHandler()});
-
-        server.setHandler(handlers);
+        server = new HttpServerFixture(port, getBase());
+        server.addBasicAuthentication(
+                "/protected/", "POC Server", Map.of("user", "password", "longuser", LONG_PASSWORD));
+        server.addSlowResponse("/slow/");
+        server.addRedirectTrap("/redirect-trap/");
         server.start();
     }
 
@@ -114,63 +51,7 @@ public class ServerTestFixture {
         return new File(resource.toURI().normalize());
     }
 
-    public void stop() throws Exception {
+    public void stop() {
         server.stop();
-        server.join();
-    }
-
-    public static final class TimingServlet extends HttpServlet {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
-            String basePath = req.getServletPath();
-            String subPath = req.getRequestURI().substring(basePath.length());
-
-            File base;
-            try {
-                base = getBase();
-            } catch (URISyntaxException e) {
-                resp.sendError(
-                        HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
-                        "Cannot find server document root in classpath: " + SERVER_ROOT_RESOURCE_PATH);
-                return;
-            }
-
-            File f = new File(base, "slow" + subPath);
-            try (InputStream in = new FileInputStream(f)) {
-                OutputStream out = resp.getOutputStream();
-
-                int read;
-                byte[] buf = new byte[64];
-                while ((read = in.read(buf)) > -1) {
-                    System.out.println("Sending " + read + " bytes (after pausing 1 seconds)...");
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-
-                    out.write(buf, 0, read);
-                }
-
-                out.flush();
-            }
-        }
-    }
-
-    public static final class InfiniteRedirectionServlet extends HttpServlet {
-        private static final long serialVersionUID = 1L;
-
-        static int redirCount = 0;
-
-        @Override
-        protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
-            String path = req.getServletPath();
-            String subPath = req.getRequestURI().substring(path.length());
-
-            path += subPath + "-" + (++redirCount);
-            resp.sendRedirect(path);
-        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -284,12 +284,6 @@ under the License.
         </exclusions>
       </dependency>
 
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
-        <version>10.0.24</version>
-        <scope>test</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Replaces the test-only embedded Jetty servers with the JDK `HttpServer`.

This removes the EOL Jetty dependency while retaining Maven Indexer's Java 11 target. The shared fixture preserves static repository serving, Basic authentication, delayed streaming responses, and redirect-loop coverage.

Closes #760